### PR TITLE
Fix EF InvalidOperationException on Startup

### DIFF
--- a/src/MusicStore/Models/SampleData.cs
+++ b/src/MusicStore/Models/SampleData.cs
@@ -36,9 +36,15 @@ namespace MusicStore.Web.Models
         private static void AddOrUpdate<TEntity>(Func<TEntity, object> propertyToMatch, IEnumerable<TEntity> entities)
             where TEntity : class
         {
+            // Query in a separate context so that we can attach existing entities as modified
+            List<TEntity> existingData;
             using (var db = new MusicStoreContext())
             {
-                var existingData = db.Set<TEntity>().ToList();
+                existingData = db.Set<TEntity>().ToList();
+            }
+
+            using (var db = new MusicStoreContext())
+            {
                 foreach (var item in entities)
                 {
                     db.ChangeTracker.Entry(item).State = existingData.Any(g => propertyToMatch(g).Equals(propertyToMatch(item)))


### PR DESCRIPTION
The code that does an 'UPSERT' of seed data on app start was querying
existing instances and attaching as modified of seed instances on the
same context. Now that we track query results this will throw because
the context has two instances of the same entity (same key value).

Swapping to use a temporary context to query existing data.
