### PR TITLE
Setting the full path to load the Config.json.

### DIFF
--- a/src/MusicStore/project.json
+++ b/src/MusicStore/project.json
@@ -50,7 +50,10 @@
                 "System.Console": "4.0.0.0",
                 "System.Diagnostics.Debug": "4.0.10.0",
                 "System.Diagnostics.Tools": "4.0.0.0",
-                "Microsoft.ComponentModel.DataAnnotations": "4.0.10.0"
+                "Microsoft.ComponentModel.DataAnnotations": "4.0.10.0",
+				"System.Reflection": "4.0.10.0",
+				"System.Reflection.Extensions": "4.0.0.0",
+				"System.IO": "4.0.0.0"
             }
         }
     }


### PR DESCRIPTION
Specifying just the name of the file works fine on selfhost or IISExpress. When app is hosted in IIS, Config.json is being searched in the w3wp3.exe's folder path resulting in an exception.
So fixing the path of Config.json by retrieving the application base path from AppDomain.

Note: Once we have a way to get the application base path in a Helios app this piece of code will go away. 
