### PR TITLE
A few fixes with this checkin:

### DIFF
--- a/src/MusicStore/Models/IdentityModels.cs
+++ b/src/MusicStore/Models/IdentityModels.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Microsoft.AspNet.Abstractions;
+using Microsoft.AspNet.Http;
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Security;

--- a/src/MusicStore/Models/ShoppingCart.cs
+++ b/src/MusicStore/Models/ShoppingCart.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Abstractions;
+﻿using Microsoft.AspNet.Http;
 using Microsoft.Data.Entity;
 using System;
 using System.Collections.Generic;

--- a/src/MusicStore/Startup.cs
+++ b/src/MusicStore/Startup.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNet;
-using Microsoft.AspNet.Abstractions;
+using Microsoft.AspNet.Http;
 using Microsoft.AspNet.ConfigurationModel;
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.AspNet.DependencyInjection.Fallback;

--- a/src/MusicStore/project.json
+++ b/src/MusicStore/project.json
@@ -7,7 +7,7 @@
     "version": "0.1-alpha-*",
     "dependencies": {
         "Helios": "0.1-alpha-*",
-        "Microsoft.AspNet.Abstractions": "0.1-alpha-*",
+        "Microsoft.AspNet.Http": "0.1-alpha-*",
         "Microsoft.AspNet.Mvc": "0.1-alpha-*",
         "Microsoft.AspNet.Razor": "0.1-alpha-*",
         "Microsoft.AspNet.ConfigurationModel": "0.1-alpha-*",
@@ -62,7 +62,7 @@
                 "System.Console": "4.0.0.0",
                 "System.Diagnostics.Debug": "4.0.10.0",
                 "System.Diagnostics.Tools": "4.0.0.0",
-                "Microsoft.ComponentModel.DataAnnotations": "4.0.10.0",
+                "Microsoft.ComponentModel.DataAnnotations": "0.1-alpha-*",
                 "System.Reflection": "4.0.10.0",
                 "System.Reflection.Extensions": "4.0.0.0",
                 "System.IO": "4.0.0.0"


### PR DESCRIPTION
IBuilder moved to Microsoft.AspNet.Http namespace. Fixing the build break.
Changing the version number for Microsoft.ComponentModel.DataAnnotations package to 0.1-alpha-*.
