### PR TITLE
appSetting "K" to specify the CLR to be loaded is no longer being honored

### DIFF
--- a/src/MusicStore/web.config
+++ b/src/MusicStore/web.config
@@ -7,9 +7,6 @@
   </system.web>
 
   <appSettings>
-    <!-- Change below value to 'false' to run on full desktop -->
-    <add key="K" value="true" />
-
     <!-- This will turn on detailed errors when deployed to remote servers -->
     <!-- This setting is not recommended for production -->
     <add key="K_DETAILED_ERRORS" value="true" />


### PR DESCRIPTION
Removing the appSetting from web.config
