### PR TITLE
This fixes MusicStore #105.

### DIFF
--- a/src/MusicStore/Controllers/CheckoutController.cs
+++ b/src/MusicStore/Controllers/CheckoutController.cs
@@ -33,7 +33,7 @@ namespace MusicStore.Controllers
         // POST: /Checkout/AddressAndPayment
 
         [HttpPost]
-        public async Task<IActionResult> AddressAndPayment(Order order)
+        public async Task<IActionResult> AddressAndPayment(Orders order)
         {
             var formCollection = await Context.Request.GetFormAsync();
 

--- a/src/MusicStore/Models/MusicStoreContext.cs
+++ b/src/MusicStore/Models/MusicStoreContext.cs
@@ -18,7 +18,7 @@ namespace MusicStore.Models
 
         public DbSet<Album> Albums { get; set; }
         public DbSet<Artist> Artists { get; set; }
-        public DbSet<Order> Orders { get; set; }
+        public DbSet<Orders> Orders { get; set; }
         public DbSet<Genre> Genres { get; set; }
         public DbSet<CartItem> CartItems { get; set; }
         public DbSet<OrderDetail> OrderDetails { get; set; }
@@ -32,7 +32,7 @@ namespace MusicStore.Models
         {
             builder.Entity<Album>().Key(a => a.AlbumId);
             builder.Entity<Artist>().Key(a => a.ArtistId);
-            builder.Entity<Order>().Key(o => o.OrderId).StorageName("[Order]");
+            builder.Entity<Orders>().Key(o => o.OrderId).StorageName("Orders");
             builder.Entity<Genre>().Key(g => g.GenreId);
             builder.Entity<CartItem>().Key(c => c.CartItemId);
             builder.Entity<OrderDetail>().Key(o => o.OrderDetailId);

--- a/src/MusicStore/Models/Order.cs
+++ b/src/MusicStore/Models/Order.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations;
 namespace MusicStore.Models
 {
     //[Bind(Include = "FirstName,LastName,Address,City,State,PostalCode,Country,Phone,Email")]
-    public class Order
+    public class Orders
     {
         [ScaffoldColumn(false)]
         public int OrderId { get; set; }

--- a/src/MusicStore/Models/OrderDetail.cs
+++ b/src/MusicStore/Models/OrderDetail.cs
@@ -9,6 +9,6 @@
         public decimal UnitPrice { get; set; }
 
         public virtual Album Album { get; set; }
-        public virtual Order Order { get; set; }
+        public virtual Orders Order { get; set; }
     }
 }

--- a/src/MusicStore/Models/ShoppingCart.cs
+++ b/src/MusicStore/Models/ShoppingCart.cs
@@ -139,7 +139,7 @@ namespace MusicStore.Models
             return total;
         }
 
-        public int CreateOrder(Order order)
+        public int CreateOrder(Orders order)
         {
             decimal orderTotal = 0;
 

--- a/src/MusicStore/Views/Checkout/AddressAndPayment.cshtml
+++ b/src/MusicStore/Views/Checkout/AddressAndPayment.cshtml
@@ -1,4 +1,4 @@
-﻿@model MusicStore.Models.Order
+﻿@model MusicStore.Models.Orders
 
 @{
     //TODO: Until we have a way to specify the layout page at application level.


### PR DESCRIPTION
To workaround an EF issue, MusicStore was using name Order (which is a SQL
reserved word) with sql quotes like [Order]. A recent EF check-in added
quotes around all names which caused it to be double quoted like [[Order]].

Just removing quotes does not fix the issue, because it looks like the EF
check-in missed quoting some words in some places. So Order is renamed to Orders
for now. @maumar (who investigated this issue today) will do a little more
investigation on EF tomorrow and file a bug on that repo. 

This is a workaround to make MusicStore "checkout" scenario work.
