### PR TITLE
Fixing a test bug resulting in a null reference

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -88,6 +88,8 @@ namespace E2ETests
             };
 
             var hostProcess = Process.Start(startInfo);
+            //Sometimes reading MainModule returns null if called immediately after starting process.
+            Thread.Sleep(1 * 1000);
             Console.WriteLine("Started {0}. Process Id : {1}", hostProcess.MainModule.FileName, hostProcess.Id);
             WaitTillDbCreated(identityDbName);
 


### PR DESCRIPTION
After starting the klr.exe process, Process.MainModule.FileName returns null if checked soon. Adding a thread sleep to solve this issue.
