### PR TITLE
Enabling CoreCLR variation of the test

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -48,6 +48,8 @@ namespace E2ETests
             string applicationPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, APP_RELATIVE_PATH));
             //Tweak the %PATH% to the point to the right KREFLAVOR
             Environment.SetEnvironmentVariable("PATH", SwitchPathToKreFlavor(kreFlavor));
+            //To avoid the KRE_DEFAULT_LIB of the test process flowing into Helios, set it to empty
+            Environment.SetEnvironmentVariable("KRE_DEFAULT_LIB", string.Empty);
 
             if (hostType == HostType.Helios)
             {

--- a/test/E2ETests/SmokeTests.cs
+++ b/test/E2ETests/SmokeTests.cs
@@ -18,7 +18,7 @@ namespace E2ETests
         [Theory]
         [InlineData(HostType.Helios, KreFlavor.DesktopClr, "http://localhost:5001/")]
         [InlineData(HostType.SelfHost, KreFlavor.DesktopClr, "http://localhost:5002/")]
-        //[InlineData(HostType.Helios, KreFlavor.CoreClr, "http://localhost:5001/")]
+        [InlineData(HostType.Helios, KreFlavor.CoreClr, "http://localhost:5001/")]
         [InlineData(HostType.SelfHost, KreFlavor.CoreClr, "http://localhost:5002/")]
         public void SmokeTestSuite(HostType hostType, KreFlavor kreFlavor, string applicationBaseUrl)
         {


### PR DESCRIPTION
Value of the KRE_DEFAULT_LIB of the 'k test' process was flowing into Helios resulting in an exception. As the test is always running on desktop clr, the value of this variable always points to the desktop KRE path resulting in the exception. This fix will fix the issue.
