### PR TITLE
React to Identity changes

### DIFF
--- a/src/MusicStore.Spa/Models/IdentityModels.cs
+++ b/src/MusicStore.Spa/Models/IdentityModels.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.OptionsModel;
 
 namespace MusicStore.Models
 {
-    public class ApplicationUser : User { }
+    public class ApplicationUser : IdentityUser { }
 
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser> 
     {

--- a/src/MusicStore.Spa/Startup.cs
+++ b/src/MusicStore.Spa/Startup.cs
@@ -43,8 +43,7 @@ namespace MusicStore.Spa
                     .AddSqlServer();
 
                 // Add Identity services to the service container
-                services.AddIdentity<ApplicationUser>()
-                    .AddEntityFramework<ApplicationUser, ApplicationDbContext>()
+                services.AddIdentitySqlServer<ApplicationDbContext, ApplicationUser>()
                     .AddHttpSignIn();
 
                 // Add application services to the service container

--- a/src/MusicStore/Models/IdentityModels.cs
+++ b/src/MusicStore/Models/IdentityModels.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.EntityFramework;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.OptionsModel;
 
 namespace MusicStore.Models
 {
-    public class ApplicationUser : User { }
+    public class ApplicationUser : IdentityUser { }
 
     public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {

--- a/src/MusicStore/Startup.cs
+++ b/src/MusicStore/Startup.cs
@@ -44,8 +44,7 @@ namespace MusicStore
                     options.UseSqlServer(configuration.Get("Data:DefaultConnection:ConnectionString")));
 
                 // Add Identity services to the services container
-                services.AddIdentity<ApplicationUser>()
-                        .AddEntityFramework<ApplicationUser, ApplicationDbContext>()
+                services.AddIdentitySqlServer<ApplicationDbContext, ApplicationUser>()
                         .AddHttpSignIn();
 
                 // Add MVC services to the services container


### PR DESCRIPTION
@Eilon @davidfowl thoughts on the new extension method name?

`AddIdentity().AddEntityFramework()` combined into ==> `AddIdentitySqlServer()`
Switch to use common `IdentityUser` entity (EF specific `User` removed)
