### PR TITLE
Fixing CopyAspNetLoader batch file to consider the new location of AspNe...

### DIFF
--- a/src/MusicStore/CopyAspNetLoader.cmd
+++ b/src/MusicStore/CopyAspNetLoader.cmd
@@ -1,7 +1,8 @@
 REM copy the AspNet.Loader.dll to bin folder
 md bin
 
+SET ASPNETLOADER_PACKAGE_BASEPATH=%USERPROFILE%\.kpm\packages\Microsoft.AspNet.Loader.IIS.Interop
 REM figure out the path of AspNet.Loader.dll
-FOR /F %%j IN ('dir /b /o:-d ..\..\packages\Microsoft.AspNet.Loader.IIS.Interop*') do (SET AspNetLoaderPath=..\..\packages\%%j\tools\AspNet.Loader.dll)
+FOR /F %%j IN ('dir /b /o:-d %ASPNETLOADER_PACKAGE_BASEPATH%\*') do (SET AspNetLoaderPath=%ASPNETLOADER_PACKAGE_BASEPATH%\%%j\tools\AspNet.Loader.dll)
 echo Found AspNetLoader.dll at %AspNetLoaderPath%. Copying to bin\
 copy %AspNetLoaderPath% bin\


### PR DESCRIPTION
...t.Loader.dll

With a recent change Aspnet.Loader.dll will be restored to %userprofile%.kpm\packages. Fixing the batch file accordingly.
