### PR TITLE
Fixing a test failure due to a recent change.

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -150,6 +150,8 @@ namespace E2ETests
                     var watchResult = dbWatch.WaitForChanged(WatcherChangeTypes.Created, 60 * 1000);
                     if (watchResult.ChangeType == WatcherChangeTypes.Created)
                     {
+                        //This event is fired immediately after the localdb file is created. Give it a while to finish populating data and start the application.
+                        Thread.Sleep(2 * 1000);
                         Console.WriteLine("Database file created '{0}'. Proceeding with the tests.", identityDBFullPath);
                     }
                     else

--- a/test/E2ETests/SmokeTests.cs
+++ b/test/E2ETests/SmokeTests.cs
@@ -406,7 +406,7 @@ namespace E2ETests
             var responseContent = response.Content.ReadAsStringAsync().Result;
             Assert.Contains(albumName, responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("http://myapp/testurl", responseContent, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("<a href=\"/StoreManager/Edit/463\">Edit</a>", responseContent, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(string.Format("<a href=\"/StoreManager/Edit/{0}\">Edit</a>", albumId), responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<a href=\"/StoreManager\">Back to List</a>", responseContent, StringComparison.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
Adding some delay for the selfhost tests. With the recent change of merging the dbs selfhost based tests start even before the data is populated into the db & application start. Adding a slight delay to allow the setup finish.
And fixing a test bug that was not surfacing. Was checking with a fixed album id. This worked before as the id created was always 453.
