### PR TITLE
update proj.json for musicstore to take wider set of packagenames for Al...

### DIFF
--- a/src/MusicStore/project.json
+++ b/src/MusicStore/project.json
@@ -5,17 +5,17 @@
     "description": "Music store application on K",
     "version": "1.0.0-alpha2",
     "dependencies": {
-        "Microsoft.AspNet.Server.IIS": "1.0.0-alpha2",
-        "Microsoft.AspNet.Mvc": "6.0.0-alpha2",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-alpha2",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-alpha2",
-        "Microsoft.AspNet.Identity.EntityFramework": "3.0.0-alpha2",
-        "Microsoft.AspNet.Identity.Authentication": "3.0.0-alpha2",
-        "Microsoft.AspNet.Security.Cookies": "1.0.0-alpha2",
-        "Microsoft.AspNet.StaticFiles": "1.0.0-alpha2",
-        "EntityFramework.SqlServer": "7.0.0-alpha2",
-        "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-alpha2",
-        "Microsoft.Framework.OptionsModel": "1.0.0-alpha2"
+        "Microsoft.AspNet.Server.IIS": "1.0.0-alpha2-*",
+        "Microsoft.AspNet.Mvc": "6.0.0-alpha2-*",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-alpha2-*",
+        "Microsoft.AspNet.Diagnostics": "1.0.0-alpha2-*",
+        "Microsoft.AspNet.Identity.EntityFramework": "3.0.0-alpha2-*",
+        "Microsoft.AspNet.Identity.Authentication": "3.0.0-alpha2-*",
+        "Microsoft.AspNet.Security.Cookies": "1.0.0-alpha2-*",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-alpha2-*",
+        "EntityFramework.SqlServer": "7.0.0-alpha2-*",
+        "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-alpha2-*",
+        "Microsoft.Framework.OptionsModel": "1.0.0-alpha2-*"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5002",


### PR DESCRIPTION
This is to allow command line execution run smoothly per our UE documentation.  Currently the MyGet release feed or nightly feed does not have the specific official alpha build installed by CTP2 "KRE-svrc50-x86.1.0.0-alpha2".
