### PR TITLE
Changing the tests to use Dev14 connection string

### DIFF
--- a/test/E2ETests/DbUtils.cs
+++ b/test/E2ETests/DbUtils.cs
@@ -13,7 +13,7 @@ namespace E2ETests
             try
             {
                 Console.WriteLine("Trying to drop database '{0}'", databaseName);
-                using (var conn = new SqlConnection(@"Server=(localdb)\v11.0;Database=master;Trusted_Connection=True;"))
+                using (var conn = new SqlConnection(@"Server=(localdb)\MSSQLLocalDB;Database=master;Trusted_Connection=True;"))
                 {
                     conn.Open();
 

--- a/test/E2ETests/SmokeTests.cs
+++ b/test/E2ETests/SmokeTests.cs
@@ -9,7 +9,7 @@ namespace E2ETests
 {
     public class SmokeTests
     {
-        private const string Connection_string_Format = "Server=(localdb)\\v11.0;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true";
+        private const string Connection_string_Format = "Server=(localdb)\\MSSQLLocalDB;Database={0};Trusted_Connection=True;MultipleActiveResultSets=true";
 
         private string ApplicationBaseUrl;
         private HttpClient httpClient;
@@ -32,7 +32,7 @@ namespace E2ETests
         {
             Console.WriteLine("Variation Details : HostType = {0}, KreFlavor = {1}, Architecture = {2}, applicationBaseUrl = {3}", hostType, kreFlavor, architecture, applicationBaseUrl);
 
-            // Check if processor architecture is x64, else ship test
+            // Check if processor architecture is x64, else skip test
             if (architecture == KreArchitecture.x64 && !Environment.Is64BitOperatingSystem)
             {
                 Console.WriteLine("Skipping x64 test since machine is of type x86");


### PR DESCRIPTION
Currently to run the tests we need to have Dev12 localdb installed on the machine.
For this to run successfully we need to have Dev14 installed on CI.

/cc @pranavkm
