### PR TITLE
@Html.ValueFor replaced with @Html.DisplayFor

### DIFF
--- a/src/MusicStore/Views/Store/Details.cshtml
+++ b/src/MusicStore/Views/Store/Details.cshtml
@@ -21,7 +21,7 @@
     </p>
     <p>
         <em>Price:</em>
-        @Html.ValueFor(model => model.Price)
+        @Html.DisplayFor(model => model.Price)
     </p>
     <p class="button">
         @Html.ActionLink("Add to cart", "AddToCart", "ShoppingCart", new { id = Model.AlbumId })

--- a/src/MusicStore/Views/StoreManager/Details.cshtml
+++ b/src/MusicStore/Views/StoreManager/Details.cshtml
@@ -15,7 +15,7 @@
         </dt>
 
         <dd>
-            @Html.ValueFor(model => model.Artist.Name)
+            @Html.DisplayFor(model => model.Artist.Name)
         </dd>
 
         <dt>
@@ -23,7 +23,7 @@
         </dt>
 
         <dd>
-            @Html.ValueFor(model => model.Genre.Name)
+            @Html.DisplayFor(model => model.Genre.Name)
         </dd>
 
         <dt>
@@ -31,7 +31,7 @@
         </dt>
 
         <dd>
-            @Html.ValueFor(model => model.Title)
+            @Html.DisplayFor(model => model.Title)
         </dd>
 
         <dt>
@@ -39,7 +39,7 @@
         </dt>
 
         <dd>
-            @Html.ValueFor(model => model.Price)
+            @Html.DisplayFor(model => model.Price)
         </dd>
 
         <dt>
@@ -47,7 +47,7 @@
         </dt>
 
         <dd>
-            @Html.ValueFor(model => model.AlbumArtUrl)
+            @Html.DisplayFor(model => model.AlbumArtUrl)
         </dd>
 
     </dl>

--- a/src/MusicStore/Views/StoreManager/Index.cshtml
+++ b/src/MusicStore/Views/StoreManager/Index.cshtml
@@ -42,7 +42,7 @@
     {
     <tr>
         <td>
-            @Html.ValueFor(modelItem => item.Genre.Name)
+            @Html.DisplayFor(modelItem => item.Genre.Name)
         </td>
         <td>
             @Truncate(item.Artist.Name, 25)
@@ -51,7 +51,7 @@
             @Truncate(item.Title, 25)
         </td>
         <td>
-            @Html.ValueFor(modelItem => item.Price)
+            @Html.DisplayFor(modelItem => item.Price)
         </td>
         <td>
             @Html.ActionLink("Edit", "Edit", new { id = item.AlbumId }) |


### PR DESCRIPTION
The original sample used @Html.DisplayFor. While porting I changed it to use ValueFor. Xinyang pointed out this difference.

Fixing this so that it can be easily compared with the original sample. The results of the view unchanged.

/CC @xqiu
