### PR TITLE
Fixing a build break

### DIFF
--- a/src/MusicStore.Spa/Helpers/AngularHtmlHelper'T.cs
+++ b/src/MusicStore.Spa/Helpers/AngularHtmlHelper'T.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Mvc.Rendering
 
         public IEnumerable<ModelClientValidationRule> GetClientValidators(string name, ModelMetadata metadata)
         {
-            return GetClientValidationRules(name, metadata);
+            return GetClientValidationRules(metadata, name);
         }
 
         public HtmlString GetFullHtmlFieldId(string expression)


### PR DESCRIPTION
GetClientValidationRules() method's parameter order reversed with a recent MVC change.
