### PR TITLE
Enabling the test code to run on mono

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -56,6 +56,11 @@ namespace E2ETests
 
         public static Process StartApplication(ServerType hostType, KreFlavor kreFlavor, KreArchitecture kreArchitecture, string identityDbName)
         {
+            if (kreFlavor == KreFlavor.Mono)
+            {
+                throw new NotImplementedException("Not implemented for Mono");
+            }
+
             string applicationPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, APP_RELATIVE_PATH));
             //Tweak the %PATH% to the point to the right KREFLAVOR
             Environment.SetEnvironmentVariable("PATH", SwitchPathToKreFlavor(kreFlavor, kreArchitecture));

--- a/test/E2ETests/KreFlavor.cs
+++ b/test/E2ETests/KreFlavor.cs
@@ -3,6 +3,7 @@
     public enum KreFlavor
     {
         DesktopClr,
-        CoreClr
+        CoreClr,
+        Mono
     }
 }


### PR DESCRIPTION
This does not include the deployment helper on mono. So the test needs to point to a statically deployed application url to run.
There are some bugs in mono Httpclient like in case of 302's RequestMessage's Uri not modified, cookies not cleared in cookie container etc. I will file bugs in mono on those and this is a work around until then.

There is still more work and refactoring. This is a first step.
