### PR TITLE
Increasing the wait time out to 3 seconds after the db file is created.

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -174,7 +174,7 @@ namespace E2ETests
                     if (watchResult.ChangeType == WatcherChangeTypes.Created)
                     {
                         //This event is fired immediately after the localdb file is created. Give it a while to finish populating data and start the application.
-                        Thread.Sleep(2 * 1000);
+                        Thread.Sleep(3 * 1000);
                         Console.WriteLine("Database file created '{0}'. Proceeding with the tests.", identityDBFullPath);
                     }
                     else


### PR DESCRIPTION
A couple of selfhost variations are failing on some of the new CI machines. While trying to reproduce I see that the klr.exe processes are lauching fine. But the tests fail for a couple of self-host variations. Only suspicion is this time out as the client gets a socket exception. It is possible that client is making a request before the server is ready.
