### PR TITLE
Updating instructions to run the sample on Mono

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,12 @@ This project is part of ASP.NET vNext. You can find samples, documentation and g
 * **[CustomHost]:**
 	6. Run ```k run``` (This hosts the app in a console application - Application started at URL **http://localhost:5003/**)
 
+### To run the sample on Mac/Mono:
+* Follow [Home](https://github.com/aspnet/home) instructions to install mono, kvm on Mac
+* Open a command prompt and cd ```\src\MusicStore\```
+* Execute ``kpm restore```
+* Try `k kestrel` to run the application
+**NOTE: On Mono since SQL client is not available the sample uses an InMemoryStore to run the application. So the changes that you make will not be persisted.
+
 ### Note:
 1. Application is started on different ports on different hosts. To change the port or URL modify ```Helios.cmd``` or project.json commands section in case of self-host and customhost.


### PR DESCRIPTION
With some recent product bug fixes the sample can now run on Mono. The sample uses InMemory store to run on mono due to lack of SqlClient.
