### PR TITLE
Increasing the wait timeout after the application deployment

### DIFF
--- a/test/E2ETests/DeploymentUtility.cs
+++ b/test/E2ETests/DeploymentUtility.cs
@@ -174,7 +174,7 @@ namespace E2ETests
                     if (watchResult.ChangeType == WatcherChangeTypes.Created)
                     {
                         //This event is fired immediately after the localdb file is created. Give it a while to finish populating data and start the application.
-                        Thread.Sleep(3 * 1000);
+                        Thread.Sleep(5 * 1000);
                         Console.WriteLine("Database file created '{0}'. Proceeding with the tests.", identityDBFullPath);
                     }
                     else


### PR DESCRIPTION
I'm starting to see that tests start running too soon before the application started. Increasing the wait time to a bigger number.

It will increase the test runtime of each selfhost variation by a couple more seconds, but it will increase the reliability.
