### PR TITLE
Cleanup

### DIFF
--- a/src/MusicStore/Helios.cmd
+++ b/src/MusicStore/Helios.cmd
@@ -3,4 +3,4 @@ SET KRE_HOME=%USERPROFILE%\.kre\
 REM copy the AspNet.Loader.dll to the bin folder
 call CopyAspNetLoader.cmd
 
-"%ProgramFiles(x86)%\iis Express\iisexpress.exe"  /port:5001 /path:"%cd%"
+"%ProgramFiles(x86)%\iis Express\iisexpress.exe" /port:5001 /path:"%cd%"

--- a/src/MusicStore/project.json
+++ b/src/MusicStore/project.json
@@ -5,6 +5,7 @@
     "description": "Music store application on K",
     "version": "1.0.0-*",
     "compilationOptions": { "warningsAsErrors": true, "define": [ "DEMO", "TESTING" ] },
+    "pack-exclude":  "*.cmd",
     "webroot": "wwwroot",
     "dependencies": {
         "Kestrel": "1.0.0-*",

--- a/test/E2ETests/NtlmAuthentationTest.cs
+++ b/test/E2ETests/NtlmAuthentationTest.cs
@@ -9,17 +9,17 @@ namespace E2ETests
     public partial class SmokeTests
     {
         [Theory]
-        [InlineData(ServerType.Helios, KreFlavor.DesktopClr, KreArchitecture.x86, "http://localhost:5001/", false)]
-        [InlineData(ServerType.WebListener, KreFlavor.DesktopClr, KreArchitecture.x86, "http://localhost:5002/", false)]
-        [InlineData(ServerType.Helios, KreFlavor.DesktopClr, KreArchitecture.amd64, "http://localhost:5001/", false)]
+        [InlineData(ServerType.Helios, KreFlavor.DesktopClr, KreArchitecture.x86, "http://localhost:5001/")]
+        [InlineData(ServerType.WebListener, KreFlavor.DesktopClr, KreArchitecture.x86, "http://localhost:5002/")]
+        [InlineData(ServerType.Helios, KreFlavor.DesktopClr, KreArchitecture.amd64, "http://localhost:5001/")]
         //WindowsIdentity not available on CoreCLR
-        //[InlineData(ServerType.Helios, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5001/", false)]
-        //[InlineData(ServerType.WebListener, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5002/", false)]
-        public void NtlmAuthenticationTest(ServerType serverType, KreFlavor kreFlavor, KreArchitecture architecture, string applicationBaseUrl, bool RunTestOnMono = false)
+        //[InlineData(ServerType.Helios, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5001/")]
+        //[InlineData(ServerType.WebListener, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5002/")]
+        public void NtlmAuthenticationTest(ServerType serverType, KreFlavor kreFlavor, KreArchitecture architecture, string applicationBaseUrl)
         {
             Console.WriteLine("Variation Details : HostType = {0}, KreFlavor = {1}, Architecture = {2}, applicationBaseUrl = {3}", serverType, kreFlavor, architecture, applicationBaseUrl);
 
-            if (Helpers.SkipTestOnCurrentConfiguration(RunTestOnMono, architecture))
+            if (Helpers.SkipTestOnCurrentConfiguration(false, architecture))
             {
                 Assert.True(true);
                 return;

--- a/test/E2ETests/project.json
+++ b/test/E2ETests/project.json
@@ -8,15 +8,15 @@
         "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*",
         "Xunit.KRunner": "1.0.0-*",
         "Microsoft.AspNet.SignalR.Client": "2.1.1",
-        "Microsoft.AspNet.WebUtilities": "1.0.0-*"
+        "Microsoft.AspNet.WebUtilities": "1.0.0-*",
+        "System.Net.Http": "4.0.0.0",
+        "System.Runtime": "4.0.20.0",
+        "System.Runtime.Extensions": "4.0.10.0"
     },
     "frameworks": {
         "aspnet50": {
-            "dependencies": {
-                "System.Runtime": "",
-                "System.Runtime.Extensions": "",
-                "System.Net.Http": "",
-                "System.Net.Http.WebRequest": "",
+            "frameworkAssemblies": {
+                //https://github.com/aspnet/KRuntime/issues/687
                 "System.Xml": "",
                 "System.Data": ""
             }


### PR DESCRIPTION
1. Moving framework assembly references to frameworkassemblies node.
   Moving the framework references Removing the RunOnMono flag on Ntlm tests as it never runs on mono
2. Deleted a space from the batch file
3. Adding some pack-exclude items
4. Some general test cleanup.
