### PR TITLE
Enabling native module variations.

### DIFF
--- a/test/E2ETests/Helpers.cs
+++ b/test/E2ETests/Helpers.cs
@@ -43,16 +43,16 @@ namespace E2ETests
                 return true;
             }
 
-            //if (serverType == ServerType.IISNativeModule && 
-            //    Environment.GetEnvironmentVariable("IIS_NATIVE_MODULE_SETUP") != "true")
-            //{
-            //    // Native module variations require IIS setup. Once native module is setup on IIS, set the value of the environment
-            //    // variable to true to run the native module variation.
-            //    // TODO: Need a better way to detect native module on the machine.
-            //    Console.WriteLine("Skipping Native module test since native module is not installed on IIS.");
-            //    Console.WriteLine("Setup the native module and set the IIS_NATIVE_MODULE_SETUP to true to run the variation.");
-            //    return true;
-            //}
+            if (serverType == ServerType.IISNativeModule &&
+                Environment.GetEnvironmentVariable("IIS_NATIVE_MODULE_SETUP") != "true")
+            {
+                // Native module variations require IIS setup. Once native module is setup on IIS, set the value of the environment
+                // variable to true to run the native module variation.
+                // TODO: Need a better way to detect native module on the machine.
+                Console.WriteLine("Skipping Native module test since native module is not installed on IIS.");
+                Console.WriteLine("Setup the native module and set the IIS_NATIVE_MODULE_SETUP to true to run the variation.");
+                return true;
+            }
 
             return false;
         }

--- a/test/E2ETests/SmokeTests.cs
+++ b/test/E2ETests/SmokeTests.cs
@@ -27,8 +27,8 @@ namespace E2ETests
         [InlineData(ServerType.Kestrel, KreFlavor.Mono, KreArchitecture.x86, "http://localhost:5004/", true)]
         [InlineData(ServerType.Helios, KreFlavor.CoreClr, KreArchitecture.amd64, "http://localhost:5001/", false)]
         [InlineData(ServerType.Kestrel, KreFlavor.CoreClr, KreArchitecture.amd64, "http://localhost:5004/", false)]
-        //[InlineData(ServerType.IISNativeModule, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5005/", false)]
-        //[InlineData(ServerType.IISNativeModule, KreFlavor.CoreClr, KreArchitecture.amd64, "http://localhost:5005/", false)]
+        [InlineData(ServerType.IISNativeModule, KreFlavor.CoreClr, KreArchitecture.x86, "http://localhost:5005/", false)]
+        [InlineData(ServerType.IISNativeModule, KreFlavor.CoreClr, KreArchitecture.amd64, "http://localhost:5005/", false)]
         public void SmokeTestSuite(ServerType serverType, KreFlavor kreFlavor, KreArchitecture architecture, string applicationBaseUrl, bool runTestOnMono)
         {
             Console.WriteLine("Variation Details : HostType = {0}, KreFlavor = {1}, Architecture = {2}, applicationBaseUrl = {3}", serverType, kreFlavor, architecture, applicationBaseUrl);


### PR DESCRIPTION
These do no run unless a machine has native module setup done and an environment variable named IIS_NATIVE_MODULE_SETUP=true. So the test will get skipped on pretty much on all machines except the ones where we want to run on.
