### PR TITLE
Corrected json for mono

### DIFF
--- a/test/E2ETests/project.json
+++ b/test/E2ETests/project.json
@@ -1,5 +1,5 @@
 {
-    "compilationOptions": { "warningsAsErrors": true },
+    "compilationOptions": { "warningsAsErrors": "true" },
     "commands": {
         "test": "xunit.runner.kre"
     },


### PR DESCRIPTION
@Praburaj 

This property needs to be in quotes else it fails on mono. This is known issue with json parsing
