### PR TITLE
Fixing the KRE name issue on mono

### DIFF
--- a/test/E2ETests/Common/StartParameters.cs
+++ b/test/E2ETests/Common/StartParameters.cs
@@ -25,7 +25,7 @@
 
         public string PackedApplicationRootPath { get; set; }
 
-        public string KreName { get; set; }
+        public string Kre { get; set; }
 
         public IISApplication IISApplication { get; set; }
     }


### PR DESCRIPTION
On mono with a recent change --runtime <value> for kpm pack is null as the value is not populated.
