### PR TITLE
Increasing wait time out on mono tests

### DIFF
--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -201,7 +201,7 @@ namespace E2ETests
 
             var hostProcess = Process.Start(startInfo);
             logger.WriteInformation("Started {0}. Process Id : {1}", hostProcess.MainModule.FileName, hostProcess.Id);
-            Thread.Sleep(5 * 1000);
+            Thread.Sleep(15 * 1000);
 
             //Clear the appbase so that it does not create issues with successive runs
             Environment.SetEnvironmentVariable("KRE_APPBASE", string.Empty);


### PR DESCRIPTION
Right now since console logger is enabled there seems more delay in app start.

@suhasj 