### PR TITLE
Fixing start mono processstartinfo

### DIFF
--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -191,14 +191,13 @@ namespace E2ETests
             logger.WriteInformation("Setting the --appbase to", startParameters.ApplicationPath);
 
             var dotnet = "dotnet";
-            var dotnetMonoManaged = Path.Combine(dotnetBin, "dotnet.mono.managed.dll");
 
             var commandName = startParameters.ServerType == ServerType.Kestrel ? "kestrel" : string.Empty;
             logger.WriteInformation(string.Format("Executing command: {0} {1} {2}", dotnet, startParameters.ApplicationPath, commandName));
 
             var startInfo = new ProcessStartInfo
             {
-                FileName = monoPath,
+                FileName = dotnet,
                 Arguments = string.Format("{0} {1}", startParameters.ApplicationPath, commandName),
                 UseShellExecute = false,
                 CreateNoWindow = true,

--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -186,21 +186,20 @@ namespace E2ETests
                 KpmPack(startParameters, logger);
             }
 
-            //Mono does not have a way to pass in a --appbase switch. So it will be an environment variable. 
+            //Mono now supports --appbase 
             Environment.SetEnvironmentVariable("DOTNET_APPBASE", startParameters.ApplicationPath);
-            logger.WriteInformation("Setting the DOTNET_APPBASE to {0}", startParameters.ApplicationPath);
+            logger.WriteInformation("Setting the --appbase to", startParameters.ApplicationPath);
 
-            var monoPath = "mono";
+            var dotnet = "dotnet";
             var dotnetMonoManaged = Path.Combine(dotnetBin, "dotnet.mono.managed.dll");
-            var applicationHost = Path.Combine(dotnetBin, "Microsoft.Framework.ApplicationHost");
 
             var commandName = startParameters.ServerType == ServerType.Kestrel ? "kestrel" : string.Empty;
-            logger.WriteInformation(string.Format("Executing command: {0} {1} {2} {3}", monoPath, dotnetMonoManaged, applicationHost, commandName));
+            logger.WriteInformation(string.Format("Executing command: {0} {1} {2}", dotnet, startParameters.ApplicationPath, commandName));
 
             var startInfo = new ProcessStartInfo
             {
                 FileName = monoPath,
-                Arguments = string.Format("{0} {1} {2}", dotnetMonoManaged, applicationHost, commandName),
+                Arguments = string.Format("{0} {1}", startParameters.ApplicationPath, commandName),
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardInput = true
@@ -210,8 +209,6 @@ namespace E2ETests
             logger.WriteInformation("Started {0}. Process Id : {1}", hostProcess.MainModule.FileName, hostProcess.Id);
             Thread.Sleep(25 * 1000);
 
-            //Clear the appbase so that it does not create issues with successive runs
-            Environment.SetEnvironmentVariable("DOTNET_APPBASE", string.Empty);
             return hostProcess;
         }
 


### PR DESCRIPTION
@Praburaj 

Fixing the ProcessStartInfo to take the new format `dotnet path/to/app` command