### PR TITLE
Reenabling the open idconnect test

### DIFF
--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -187,8 +187,7 @@ namespace E2ETests
             }
 
             //Mono now supports --appbase 
-            Environment.SetEnvironmentVariable("KRE_APPBASE", startParameters.ApplicationPath);
-            logger.WriteInformation("Setting the --appbase to", startParameters.ApplicationPath);
+            logger.WriteInformation("Setting the --appbase to {0}", startParameters.ApplicationPath);
 
             var bootstrapper = "klr";
 

--- a/test/E2ETests/OpenIdConnectTests.cs
+++ b/test/E2ETests/OpenIdConnectTests.cs
@@ -9,9 +9,9 @@ namespace E2ETests
 {
     public partial class SmokeTests
     {
-        // [ConditionalTheory]
+        [ConditionalTheory]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
-        [InlineData(ServerType.IISExpress, RuntimeFlavor.DesktopClr, RuntimeArchitecture.x86, "http://localhost:5001/")]
+        [InlineData(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x86, "http://localhost:5001/")]
         public void OpenIdConnect_OnX86(ServerType serverType, RuntimeFlavor runtimeFlavor, RuntimeArchitecture architecture, string applicationBaseUrl)
         {
             OpenIdConnectTestSuite(serverType, runtimeFlavor, architecture, applicationBaseUrl);

--- a/test/E2ETests/compiler/shared/Mocks/OpenIdConnect/OpenIdConnectNotifications.cs
+++ b/test/E2ETests/compiler/shared/Mocks/OpenIdConnect/OpenIdConnectNotifications.cs
@@ -28,9 +28,9 @@ namespace MusicStore.Mocks.OpenIdConnect
         internal static async Task SecurityTokenValidated(SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> context)
         {
             Helpers.ThrowIfConditionFailed(() => context.AuthenticationTicket != null, "context.AuthenticationTicket is null.");
-            Helpers.ThrowIfConditionFailed(() => context.AuthenticationTicket.Identity != null, "context.AuthenticationTicket.Identity is null.");
-            Helpers.ThrowIfConditionFailed(() => !string.IsNullOrWhiteSpace(context.AuthenticationTicket.Identity.Name),
-                "context.AuthenticationTicket.Identity.Name is null.");
+            Helpers.ThrowIfConditionFailed(() => context.AuthenticationTicket.Principal != null, "context.AuthenticationTicket.Principal is null.");
+            Helpers.ThrowIfConditionFailed(() => context.AuthenticationTicket.Principal.Identity != null, "context.AuthenticationTicket.Principal.Identity is null.");
+            Helpers.ThrowIfConditionFailed(() => !string.IsNullOrWhiteSpace(context.AuthenticationTicket.Principal.Identity.Name), "context.AuthenticationTicket.Principal.Identity.Name is null.");
             notificationsFired.Add(nameof(SecurityTokenValidated));
             await Task.FromResult(0);
         }
@@ -48,7 +48,7 @@ namespace MusicStore.Mocks.OpenIdConnect
                 notificationsFired.Contains(nameof(SecurityTokenValidated)) &&
                 notificationsFired.Contains(nameof(AuthorizationCodeReceived)))
             {
-                context.AuthenticationTicket.Identity.AddClaim(new Claim("ManageStore", "Allowed"));
+                ((ClaimsIdentity)context.AuthenticationTicket.Principal.Identity).AddClaim(new Claim("ManageStore", "Allowed"));
             }
 
             await Task.FromResult(0);


### PR DESCRIPTION
Bug # https://github.com/aspnet/Security/issues/144 is fixed.
Reenabling the test to run on CI.