### PR TITLE
Removing a fixed waittime of 25 seconds on mono

### DIFF
--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -205,8 +205,6 @@ namespace E2ETests
 
             var hostProcess = Process.Start(startInfo);
             logger.WriteInformation("Started {0}. Process Id : {1}", hostProcess.MainModule.FileName, hostProcess.Id);
-            Thread.Sleep(25 * 1000);
-
             return hostProcess;
         }
 

--- a/test/E2ETests/Common/Helpers.cs
+++ b/test/E2ETests/Common/Helpers.cs
@@ -22,6 +22,7 @@ namespace E2ETests
             {
                 try
                 {
+                    logger.WriteWarning("Retry count {0}..", retry + 1);
                     retryBlock();
                     break; //Went through successfully
                 }
@@ -30,8 +31,8 @@ namespace E2ETests
                     if (exception.InnerException is HttpRequestException || exception.InnerException is WebException)
                     {
                         logger.WriteWarning("Failed to complete the request.", exception);
-                        logger.WriteWarning("Retrying request..");
-                        Thread.Sleep(1 * 1000); //Wait for a second before retry
+                        var waitTimeInMilliSeconds = (RunningOnMono ? 6 : 1) * 1000;
+                        Thread.Sleep(waitTimeInMilliSeconds); //Wait for a second before retry
                     }
                 }
             }


### PR DESCRIPTION
Setting an increased retry wait time. Now test will wait for 42 seconds before giving up.

@suhasj 