### PR TITLE
Updating MusicStore for better unit-testability

### DIFF
--- a/src/MusicStore.Spa/Controllers/AccountController.cs
+++ b/src/MusicStore.Spa/Controllers/AccountController.cs
@@ -11,15 +11,11 @@ namespace MusicStore.Controllers
     [Authorize]
     public class AccountController : Controller
     {
-        public AccountController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
-        {
-            UserManager = userManager;
-            SignInManager = signInManager;
-        }
+        [Activate]
+        public UserManager<ApplicationUser> UserManager { get; set; }
 
-        public UserManager<ApplicationUser> UserManager { get; private set; }
-
-        public SignInManager<ApplicationUser> SignInManager { get; private set; }
+        [Activate]
+        public SignInManager<ApplicationUser> SignInManager { get; set; }
 
         [AllowAnonymous]
         //Bug: https://github.com/aspnet/WebFx/issues/339

--- a/src/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
+++ b/src/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.AspNet.Mvc.Rendering;
@@ -17,26 +18,42 @@ namespace MusicStore.Areas.Admin.Controllers
     [Microsoft.AspNet.Mvc.Authorize("ManageStore")]
     public class StoreManagerController : Controller
     {
-        private readonly MusicStoreContext _dbContext;
-        private readonly IMemoryCache _cache;
+        private IConnectionManager _connectionManager;
         private IHubContext _announcementHub;
 
-        public StoreManagerController(
-            MusicStoreContext dbContext,
-            IConnectionManager connectionManager,
-            IMemoryCache memoryCache)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
-            _announcementHub = connectionManager.GetHubContext<AnnouncementHub>();
-            _cache = memoryCache;
+            get;
+            set;
+        }
+
+        [Activate]
+        public IMemoryCache MemoryCache
+        {
+            get;
+            set;
+        }
+
+        [Activate]
+        public IConnectionManager ConnectionManager
+        {
+            get
+            {
+                return _connectionManager;
+            }
+            set
+            {
+                _connectionManager = value;
+                _announcementHub = _connectionManager.GetHubContext<AnnouncementHub>();
+            }
         }
 
         //
         // GET: /StoreManager/
-
         public async Task<IActionResult> Index()
         {
-            var albums = await _dbContext.Albums
+            var albums = await DbContext.Albums
                 .Include(a => a.Genre)
                 .Include(a => a.Artist)
                 .ToListAsync();
@@ -46,18 +63,17 @@ namespace MusicStore.Areas.Admin.Controllers
 
         //
         // GET: /StoreManager/Details/5
-
         public async Task<IActionResult> Details(int id)
         {
             var cacheKey = GetCacheKey(id);
 
-            var album = await _cache.GetOrSet(cacheKey, async context =>
+            var album = await MemoryCache.GetOrSet(cacheKey, async context =>
             {
                 //Remove it from cache if not retrieved in last 10 minutes.
                 context.SetSlidingExpiration(TimeSpan.FromMinutes(10));
 
                 //If this returns null how do we prevent the cache to store this.
-                return await _dbContext.Albums
+                return await DbContext.Albums
                     .Where(a => a.AlbumId == id)
                     .Include(a => a.Artist)
                     .Include(a => a.Genre)
@@ -66,7 +82,7 @@ namespace MusicStore.Areas.Admin.Controllers
 
             if (album == null)
             {
-                _cache.Remove(cacheKey);
+                MemoryCache.Remove(cacheKey);
                 return View(album);
             }
 
@@ -77,20 +93,20 @@ namespace MusicStore.Areas.Admin.Controllers
         // GET: /StoreManager/Create
         public IActionResult Create()
         {
-            ViewBag.GenreId = new SelectList(_dbContext.Genres, "GenreId", "Name");
-            ViewBag.ArtistId = new SelectList(_dbContext.Artists, "ArtistId", "Name");
+            ViewBag.GenreId = new SelectList(DbContext.Genres, "GenreId", "Name");
+            ViewBag.ArtistId = new SelectList(DbContext.Artists, "ArtistId", "Name");
             return View();
         }
 
         // POST: /StoreManager/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(Album album)
+        public async Task<IActionResult> Create(CancellationToken requestAborted, Album album)
         {
             if (ModelState.IsValid)
             {
-                _dbContext.Albums.Add(album);
-                await _dbContext.SaveChangesAsync(Context.RequestAborted);
+                DbContext.Albums.Add(album);
+                await DbContext.SaveChangesAsync(requestAborted);
 
                 var albumData = new AlbumData
                 {
@@ -99,12 +115,12 @@ namespace MusicStore.Areas.Admin.Controllers
                 };
 
                 _announcementHub.Clients.All.announcement(albumData);
-                _cache.Remove("latestAlbum");
+                MemoryCache.Remove("latestAlbum");
                 return RedirectToAction("Index");
             }
 
-            ViewBag.GenreId = new SelectList(_dbContext.Genres, "GenreId", "Name", album.GenreId);
-            ViewBag.ArtistId = new SelectList(_dbContext.Artists, "ArtistId", "Name", album.ArtistId);
+            ViewBag.GenreId = new SelectList(DbContext.Genres, "GenreId", "Name", album.GenreId);
+            ViewBag.ArtistId = new SelectList(DbContext.Artists, "ArtistId", "Name", album.ArtistId);
             return View(album);
         }
 
@@ -112,7 +128,7 @@ namespace MusicStore.Areas.Admin.Controllers
         // GET: /StoreManager/Edit/5
         public async Task<IActionResult> Edit(int id)
         {
-            var album = await _dbContext.Albums.
+            var album = await DbContext.Albums.
                 Where(a => a.AlbumId == id).
                 FirstOrDefaultAsync();
 
@@ -121,8 +137,8 @@ namespace MusicStore.Areas.Admin.Controllers
                 return View(album);
             }
 
-            ViewBag.GenreId = new SelectList(_dbContext.Genres, "GenreId", "Name", album.GenreId);
-            ViewBag.ArtistId = new SelectList(_dbContext.Artists, "ArtistId", "Name", album.ArtistId);
+            ViewBag.GenreId = new SelectList(DbContext.Genres, "GenreId", "Name", album.GenreId);
+            ViewBag.ArtistId = new SelectList(DbContext.Artists, "ArtistId", "Name", album.ArtistId);
             return View(album);
         }
 
@@ -130,19 +146,19 @@ namespace MusicStore.Areas.Admin.Controllers
         // POST: /StoreManager/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(Album album)
+        public async Task<IActionResult> Edit(CancellationToken requestAborted, Album album)
         {
             if (ModelState.IsValid)
             {
-                _dbContext.Update(album);
-                await _dbContext.SaveChangesAsync(Context.RequestAborted);
+                DbContext.Update(album);
+                await DbContext.SaveChangesAsync(requestAborted);
                 //Invalidate the cache entry as it is modified
-                _cache.Remove(GetCacheKey(album.AlbumId));
+                MemoryCache.Remove(GetCacheKey(album.AlbumId));
                 return RedirectToAction("Index");
             }
 
-            ViewBag.GenreId = new SelectList(_dbContext.Genres, "GenreId", "Name", album.GenreId);
-            ViewBag.ArtistId = new SelectList(_dbContext.Artists, "ArtistId", "Name", album.ArtistId);
+            ViewBag.GenreId = new SelectList(DbContext.Genres, "GenreId", "Name", album.GenreId);
+            ViewBag.ArtistId = new SelectList(DbContext.Artists, "ArtistId", "Name", album.ArtistId);
             return View(album);
         }
 
@@ -150,23 +166,23 @@ namespace MusicStore.Areas.Admin.Controllers
         // GET: /StoreManager/RemoveAlbum/5
         public async Task<IActionResult> RemoveAlbum(int id)
         {
-            var album = await _dbContext.Albums.Where(a => a.AlbumId == id).FirstOrDefaultAsync();
+            var album = await DbContext.Albums.Where(a => a.AlbumId == id).FirstOrDefaultAsync();
             return View(album);
         }
 
         //
         // POST: /StoreManager/RemoveAlbum/5
         [HttpPost, ActionName("RemoveAlbum")]
-        public async Task<IActionResult> RemoveAlbumConfirmed(int id)
+        public async Task<IActionResult> RemoveAlbumConfirmed(CancellationToken requestAborted, int id)
         {
-            var album = await _dbContext.Albums.Where(a => a.AlbumId == id).FirstOrDefaultAsync();
+            var album = await DbContext.Albums.Where(a => a.AlbumId == id).FirstOrDefaultAsync();
 
             if (album != null)
             {
-                _dbContext.Albums.Remove(album);
-                await _dbContext.SaveChangesAsync(Context.RequestAborted);
+                DbContext.Albums.Remove(album);
+                await DbContext.SaveChangesAsync(requestAborted);
                 //Remove the cache entry as it is removed
-                _cache.Remove(GetCacheKey(id));
+                MemoryCache.Remove(GetCacheKey(id));
             }
 
             return RedirectToAction("Index");
@@ -184,7 +200,7 @@ namespace MusicStore.Areas.Admin.Controllers
         [HttpGet]
         public async Task<IActionResult> GetAlbumIdFromName(string albumName)
         {
-            var album = await _dbContext.Albums.Where(a => a.Title == albumName).FirstOrDefaultAsync();
+            var album = await DbContext.Albums.Where(a => a.Title == albumName).FirstOrDefaultAsync();
 
             if (album == null)
             {

--- a/src/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
+++ b/src/MusicStore/Areas/Admin/Controllers/StoreManagerController.cs
@@ -101,12 +101,12 @@ namespace MusicStore.Areas.Admin.Controllers
         // POST: /StoreManager/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(CancellationToken requestAborted, Album album)
+        public async Task<IActionResult> Create(Album album, CancellationToken cancellationToken)
         {
             if (ModelState.IsValid)
             {
                 DbContext.Albums.Add(album);
-                await DbContext.SaveChangesAsync(requestAborted);
+                await DbContext.SaveChangesAsync(cancellationToken);
 
                 var albumData = new AlbumData
                 {
@@ -146,12 +146,12 @@ namespace MusicStore.Areas.Admin.Controllers
         // POST: /StoreManager/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(CancellationToken requestAborted, Album album)
+        public async Task<IActionResult> Edit(Album album, CancellationToken cancellationToken)
         {
             if (ModelState.IsValid)
             {
                 DbContext.Update(album);
-                await DbContext.SaveChangesAsync(requestAborted);
+                await DbContext.SaveChangesAsync(cancellationToken);
                 //Invalidate the cache entry as it is modified
                 MemoryCache.Remove(GetCacheKey(album.AlbumId));
                 return RedirectToAction("Index");
@@ -173,14 +173,14 @@ namespace MusicStore.Areas.Admin.Controllers
         //
         // POST: /StoreManager/RemoveAlbum/5
         [HttpPost, ActionName("RemoveAlbum")]
-        public async Task<IActionResult> RemoveAlbumConfirmed(CancellationToken requestAborted, int id)
+        public async Task<IActionResult> RemoveAlbumConfirmed(int id, CancellationToken cancellationToken)
         {
             var album = await DbContext.Albums.Where(a => a.AlbumId == id).FirstOrDefaultAsync();
 
             if (album != null)
             {
                 DbContext.Albums.Remove(album);
-                await DbContext.SaveChangesAsync(requestAborted);
+                await DbContext.SaveChangesAsync(cancellationToken);
                 //Remove the cache entry as it is removed
                 MemoryCache.Remove(GetCacheKey(id));
             }

--- a/src/MusicStore/Components/AnnouncementComponent.cs
+++ b/src/MusicStore/Components/AnnouncementComponent.cs
@@ -10,18 +10,23 @@ namespace MusicStore.Components
     [ViewComponent(Name = "Announcement")]
     public class AnnouncementComponent : ViewComponent
     {
-        private readonly MusicStoreContext _dbContext;
-        private readonly IMemoryCache _cache;
-
-        public AnnouncementComponent(MusicStoreContext dbContext, IMemoryCache memoryCache)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
-            _cache = memoryCache;
+            get;
+            set;
+        }
+
+        [Activate]
+        public IMemoryCache MemoryCache
+        {
+            get;
+            set;
         }
 
         public async Task<IViewComponentResult> InvokeAsync()
         {
-            var latestAlbum = await _cache.GetOrSet("latestAlbum", async context =>
+            var latestAlbum = await MemoryCache.GetOrSet("latestAlbum", async context =>
             {
                 context.SetAbsoluteExpiration(TimeSpan.FromMinutes(10));
                 return await GetLatestAlbum();
@@ -32,7 +37,7 @@ namespace MusicStore.Components
 
         private Task<Album> GetLatestAlbum()
         {
-            var latestAlbum = _dbContext.Albums
+            var latestAlbum = DbContext.Albums
                 .OrderByDescending(a => a.Created)
                 .Where(a => (a.Created - DateTime.UtcNow).TotalDays <= 2)
                 .FirstOrDefaultAsync();

--- a/src/MusicStore/Components/CartSummaryComponent.cs
+++ b/src/MusicStore/Components/CartSummaryComponent.cs
@@ -8,11 +8,11 @@ namespace MusicStore.Components
     [ViewComponent(Name = "CartSummary")]
     public class CartSummaryComponent : ViewComponent
     {
-        private readonly MusicStoreContext _dbContext;
-
-        public CartSummaryComponent(MusicStoreContext dbContext)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
+            get;
+            set;
         }
 
         public async Task<IViewComponentResult> InvokeAsync()
@@ -27,7 +27,7 @@ namespace MusicStore.Components
 
         private async Task<IOrderedEnumerable<string>> GetCartItems()
         {
-            var cart = ShoppingCart.GetCart(_dbContext, Context);
+            var cart = ShoppingCart.GetCart(DbContext, Context);
 
             return (await cart.GetCartItems())
                 .Select(a => a.Album.Title)

--- a/src/MusicStore/Components/GenreMenuComponent.cs
+++ b/src/MusicStore/Components/GenreMenuComponent.cs
@@ -9,11 +9,11 @@ namespace MusicStore.Components
     [ViewComponent(Name = "GenreMenu")]
     public class GenreMenuComponent : ViewComponent
     {
-        private readonly MusicStoreContext _dbContext;
-
-        public GenreMenuComponent(MusicStoreContext dbContext)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
+            get;
+            set;
         }
 
         public async Task<IViewComponentResult> InvokeAsync()
@@ -34,7 +34,7 @@ namespace MusicStore.Components
             //.Take(9)
             //.ToList();
 
-            return await _dbContext.Genres.Take(9).ToListAsync();
+            return await DbContext.Genres.Take(9).ToListAsync();
         }
     }
 }

--- a/src/MusicStore/Controllers/AccountController.cs
+++ b/src/MusicStore/Controllers/AccountController.cs
@@ -35,7 +35,7 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Login(CancellationToken requestAborted, LoginViewModel model, string returnUrl = null)
+        public async Task<IActionResult> Login(CancellationToken cancellationToken, LoginViewModel model, string returnUrl = null)
         {
             if (!ModelState.IsValid)
             {
@@ -44,7 +44,7 @@ namespace MusicStore.Controllers
 
             // This doesn't count login failures towards account lockout
             // To enable password failures to trigger account lockout, change to shouldLockout: true
-            var result = await SignInManager.PasswordSignInAsync(model.Email, model.Password, model.RememberMe, shouldLockout: false, cancellationToken: requestAborted);
+            var result = await SignInManager.PasswordSignInAsync(model.Email, model.Password, model.RememberMe, shouldLockout: false, cancellationToken: cancellationToken);
             if (result.Succeeded)
             {
                 return RedirectToLocal(returnUrl);
@@ -67,9 +67,9 @@ namespace MusicStore.Controllers
         //
         // GET: /Account/VerifyCode
         [AllowAnonymous]
-        public async Task<ActionResult> VerifyCode(CancellationToken requestAborted, string provider, bool rememberMe, string returnUrl = null)
+        public async Task<ActionResult> VerifyCode(CancellationToken cancellationToken, string provider, bool rememberMe, string returnUrl = null)
         {
-            var user = await SignInManager.GetTwoFactorAuthenticationUserAsync(cancellationToken: requestAborted);
+            var user = await SignInManager.GetTwoFactorAuthenticationUserAsync(cancellationToken: cancellationToken);
             if (user == null)
             {
                 return View("Error");
@@ -79,7 +79,7 @@ namespace MusicStore.Controllers
 #if DEMO
             if (user != null)
             {
-                ViewBag.Code = await UserManager.GenerateTwoFactorTokenAsync(user, provider, cancellationToken: requestAborted);
+                ViewBag.Code = await UserManager.GenerateTwoFactorTokenAsync(user, provider, cancellationToken: cancellationToken);
             }
 #endif
             return View(new VerifyCodeViewModel { Provider = provider, ReturnUrl = returnUrl, RememberMe = rememberMe });
@@ -90,7 +90,7 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> VerifyCode(CancellationToken requestAborted, VerifyCodeViewModel model)
+        public async Task<ActionResult> VerifyCode(VerifyCodeViewModel model, CancellationToken cancellationToken)
         {
             if (!ModelState.IsValid)
             {
@@ -101,7 +101,7 @@ namespace MusicStore.Controllers
             // If a user enters incorrect codes for a specified amount of time then the user account 
             // will be locked out for a specified amount of time. 
             // You can configure the account lockout settings in IdentityConfig
-            var result = await SignInManager.TwoFactorSignInAsync(model.Provider, model.Code, model.RememberMe, model.RememberBrowser, cancellationToken: requestAborted);
+            var result = await SignInManager.TwoFactorSignInAsync(model.Provider, model.Code, model.RememberMe, model.RememberBrowser, cancellationToken: cancellationToken);
             if (result.Succeeded)
             {
                 return RedirectToLocal(model.ReturnUrl);
@@ -131,12 +131,12 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Register(CancellationToken requestAborted, RegisterViewModel model)
+        public async Task<IActionResult> Register(RegisterViewModel model, CancellationToken cancellationToken)
         {
             if (ModelState.IsValid)
             {
                 var user = new ApplicationUser { UserName = model.Email, Email = model.Email };
-                var result = await UserManager.CreateAsync(user, model.Password, cancellationToken: requestAborted);
+                var result = await UserManager.CreateAsync(user, model.Password, cancellationToken: cancellationToken);
                 if (result.Succeeded)
                 {
                     //Bug: Remember browser option missing?
@@ -145,7 +145,7 @@ namespace MusicStore.Controllers
 
                     // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=320771
                     // Send an email with this link
-                    string code = await UserManager.GenerateEmailConfirmationTokenAsync(user, cancellationToken: requestAborted);
+                    string code = await UserManager.GenerateEmailConfirmationTokenAsync(user, cancellationToken: cancellationToken);
                     var callbackUrl = Url.Action("ConfirmEmail", "Account", new { userId = user.Id, code = code }, protocol: Context.Request.Scheme);
                     var email = new IdentityMessage
                     {
@@ -153,7 +153,7 @@ namespace MusicStore.Controllers
                         Subject = "Confirm your account",
                         Body = "Please confirm your account by clicking this link: <a href=\"" + callbackUrl + "\">link</a>"
                     };
-                    await UserManager.SendMessageAsync("Email", email, cancellationToken: requestAborted);
+                    await UserManager.SendMessageAsync("Email", email, cancellationToken: cancellationToken);
 #if !DEMO
                     return RedirectToAction("Index", "Home");
 #else
@@ -172,19 +172,19 @@ namespace MusicStore.Controllers
         //
         // GET: /Account/ConfirmEmail
         [AllowAnonymous]
-        public async Task<ActionResult> ConfirmEmail(CancellationToken requestAborted, string userId, string code)
+        public async Task<ActionResult> ConfirmEmail(string userId, string code, CancellationToken cancellationToken)
         {
             if (userId == null || code == null)
             {
                 return View("Error");
             }
 
-            var user = await SignInManager.UserManager.FindByIdAsync(userId, cancellationToken: requestAborted);
+            var user = await SignInManager.UserManager.FindByIdAsync(userId, cancellationToken: cancellationToken);
             if (user == null)
             {
                 return View("Error");
             }
-            var result = await UserManager.ConfirmEmailAsync(user, code, cancellationToken: requestAborted);
+            var result = await UserManager.ConfirmEmailAsync(user, code, cancellationToken: cancellationToken);
             return View(result.Succeeded ? "ConfirmEmail" : "Error");
         }
 
@@ -201,12 +201,12 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> ForgotPassword(CancellationToken requestAborted, ForgotPasswordViewModel model)
+        public async Task<ActionResult> ForgotPassword(ForgotPasswordViewModel model, CancellationToken cancellationToken)
         {
             if (ModelState.IsValid)
             {
-                var user = await UserManager.FindByNameAsync(model.Email, cancellationToken: requestAborted);
-                if (user == null || !(await UserManager.IsEmailConfirmedAsync(user, cancellationToken: requestAborted)))
+                var user = await UserManager.FindByNameAsync(model.Email, cancellationToken: cancellationToken);
+                if (user == null || !(await UserManager.IsEmailConfirmedAsync(user, cancellationToken: cancellationToken)))
                 {
                     // Don't reveal that the user does not exist or is not confirmed
                     return View("ForgotPasswordConfirmation");
@@ -214,7 +214,7 @@ namespace MusicStore.Controllers
 
                 // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=320771
                 // Send an email with this link
-                string code = await UserManager.GeneratePasswordResetTokenAsync(user, cancellationToken: requestAborted);
+                string code = await UserManager.GeneratePasswordResetTokenAsync(user, cancellationToken: cancellationToken);
                 var callbackUrl = Url.Action("ResetPassword", "Account", new { code = code }, protocol: Context.Request.Scheme);
                 var email = new IdentityMessage
                 {
@@ -222,7 +222,7 @@ namespace MusicStore.Controllers
                     Subject = "Reset Password",
                     Body = "Please reset your password by clicking here: <a href=\"" + callbackUrl + "\">link</a>"
                 };
-                await UserManager.SendMessageAsync("Email", email, cancellationToken: requestAborted);
+                await UserManager.SendMessageAsync("Email", email, cancellationToken: cancellationToken);
 #if !DEMO
                 return RedirectToAction("ForgotPasswordConfirmation");
 #else
@@ -261,19 +261,19 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> ResetPassword(CancellationToken requestAborted, ResetPasswordViewModel model)
+        public async Task<ActionResult> ResetPassword(ResetPasswordViewModel model, CancellationToken cancellationToken)
         {
             if (!ModelState.IsValid)
             {
                 return View(model);
             }
-            var user = await UserManager.FindByNameAsync(model.Email, cancellationToken: requestAborted);
+            var user = await UserManager.FindByNameAsync(model.Email, cancellationToken: cancellationToken);
             if (user == null)
             {
                 // Don't reveal that the user does not exist
                 return RedirectToAction("ResetPasswordConfirmation", "Account");
             }
-            var result = await UserManager.ResetPasswordAsync(user, model.Code, model.Password, cancellationToken: requestAborted);
+            var result = await UserManager.ResetPasswordAsync(user, model.Code, model.Password, cancellationToken: cancellationToken);
             if (result.Succeeded)
             {
                 return RedirectToAction("ResetPasswordConfirmation", "Account");
@@ -306,10 +306,10 @@ namespace MusicStore.Controllers
         //
         // GET: /Account/SendCode
         [AllowAnonymous]
-        public async Task<ActionResult> SendCode(CancellationToken requestAborted, bool rememberMe, string returnUrl = null)
+        public async Task<ActionResult> SendCode(CancellationToken cancellationToken, bool rememberMe, string returnUrl = null)
         {
             //TODO : Default rememberMe as well?
-            var user = await SignInManager.GetTwoFactorAuthenticationUserAsync(cancellationToken: requestAborted);
+            var user = await SignInManager.GetTwoFactorAuthenticationUserAsync(cancellationToken: cancellationToken);
             if (user == null)
             {
                 return View("Error");
@@ -324,7 +324,7 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> SendCode(CancellationToken requestAborted, SendCodeViewModel model)
+        public async Task<ActionResult> SendCode(SendCodeViewModel model, CancellationToken cancellationToken)
         {
             if (!ModelState.IsValid)
             {
@@ -332,7 +332,7 @@ namespace MusicStore.Controllers
             }
 
             // Generate the token and send it
-            if (!await SignInManager.SendTwoFactorCodeAsync(model.SelectedProvider, cancellationToken: requestAborted))
+            if (!await SignInManager.SendTwoFactorCodeAsync(model.SelectedProvider, cancellationToken: cancellationToken))
             {
                 return View("Error");
             }
@@ -342,16 +342,16 @@ namespace MusicStore.Controllers
         //
         // GET: /Account/ExternalLoginCallback
         [AllowAnonymous]
-        public async Task<ActionResult> ExternalLoginCallback(CancellationToken requestAborted, string returnUrl = null)
+        public async Task<ActionResult> ExternalLoginCallback(CancellationToken cancellationToken, string returnUrl = null)
         {
-            var loginInfo = await SignInManager.GetExternalLoginInfoAsync(cancellationToken: requestAborted);
+            var loginInfo = await SignInManager.GetExternalLoginInfoAsync(cancellationToken: cancellationToken);
             if (loginInfo == null)
             {
                 return RedirectToAction("Login");
             }
 
             // Sign in the user with this external login provider if the user already has a login
-            var result = await SignInManager.ExternalLoginSignInAsync(loginInfo.LoginProvider, loginInfo.ProviderKey, isPersistent: false, cancellationToken: requestAborted);
+            var result = await SignInManager.ExternalLoginSignInAsync(loginInfo.LoginProvider, loginInfo.ProviderKey, isPersistent: false, cancellationToken: cancellationToken);
             if (result.Succeeded)
             {
                 return RedirectToLocal(returnUrl);
@@ -380,7 +380,7 @@ namespace MusicStore.Controllers
         [HttpPost]
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> ExternalLoginConfirmation(CancellationToken requestAborted, ExternalLoginConfirmationViewModel model, string returnUrl = null)
+        public async Task<ActionResult> ExternalLoginConfirmation(CancellationToken cancellationToken, ExternalLoginConfirmationViewModel model, string returnUrl = null)
         {
             if (User.Identity.IsAuthenticated)
             {
@@ -390,29 +390,29 @@ namespace MusicStore.Controllers
             if (ModelState.IsValid)
             {
                 // Get the information about the user from the external login provider
-                var info = await SignInManager.GetExternalLoginInfoAsync(cancellationToken: requestAborted);
+                var info = await SignInManager.GetExternalLoginInfoAsync(cancellationToken: cancellationToken);
                 if (info == null)
                 {
                     return View("ExternalLoginFailure");
                 }
                 var user = new ApplicationUser { UserName = model.Email, Email = model.Email };
-                var result = await UserManager.CreateAsync(user, cancellationToken: requestAborted);
+                var result = await UserManager.CreateAsync(user, cancellationToken: cancellationToken);
 
 #if TESTING
                 //Just for automated testing adding a claim named 'ManageStore' - Not required for production
                 var manageClaim = info.ExternalIdentity.Claims.Where(c => c.Type == "ManageStore").FirstOrDefault();
                 if (manageClaim != null)
                 {
-                    await UserManager.AddClaimAsync(user, manageClaim, cancellationToken: requestAborted);
+                    await UserManager.AddClaimAsync(user, manageClaim, cancellationToken: cancellationToken);
                 }
 #endif
 
                 if (result.Succeeded)
                 {
-                    result = await UserManager.AddLoginAsync(user, info, cancellationToken: requestAborted);
+                    result = await UserManager.AddLoginAsync(user, info, cancellationToken: cancellationToken);
                     if (result.Succeeded)
                     {
-                        await SignInManager.SignInAsync(user, isPersistent: false, cancellationToken: requestAborted);
+                        await SignInManager.SignInAsync(user, isPersistent: false, cancellationToken: cancellationToken);
                         return RedirectToLocal(returnUrl);
                     }
                 }
@@ -460,9 +460,9 @@ namespace MusicStore.Controllers
             }
         }
 
-        private async Task<ApplicationUser> GetCurrentUserAsync(CancellationToken requestAborted)
+        private async Task<ApplicationUser> GetCurrentUserAsync(CancellationToken cancellationToken)
         {
-            return await UserManager.FindByIdAsync(Context.User.Identity.GetUserId(), cancellationToken: requestAborted);
+            return await UserManager.FindByIdAsync(Context.User.Identity.GetUserId(), cancellationToken: cancellationToken);
         }
 
         private ActionResult RedirectToLocal(string returnUrl)

--- a/src/MusicStore/Controllers/CheckoutController.cs
+++ b/src/MusicStore/Controllers/CheckoutController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Principal;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using MusicStore.Models;
@@ -11,16 +12,16 @@ namespace MusicStore.Controllers
     public class CheckoutController : Controller
     {
         private const string PromoCode = "FREE";
-        private readonly MusicStoreContext _dbContext;
 
-        public CheckoutController(MusicStoreContext dbContext)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
-        }
+            get;
+            set;
+        } 
 
         //
         // GET: /Checkout/
-
         public IActionResult AddressAndPayment()
         {
             return View();
@@ -31,7 +32,7 @@ namespace MusicStore.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> AddressAndPayment(Order order)
+        public async Task<IActionResult> AddressAndPayment(CancellationToken requestAborted, Order order)
         {
             var formCollection = await Context.Request.ReadFormAsync();
 
@@ -48,14 +49,14 @@ namespace MusicStore.Controllers
                     order.OrderDate = DateTime.Now;
 
                     //Add the Order
-                    _dbContext.Orders.Add(order);
+                    DbContext.Orders.Add(order);
 
                     //Process the order
-                    var cart = ShoppingCart.GetCart(_dbContext, Context);
+                    var cart = ShoppingCart.GetCart(DbContext, Context);
                     await cart.CreateOrder(order);
 
                     // Save all changes
-                    await _dbContext.SaveChangesAsync(Context.RequestAborted);
+                    await DbContext.SaveChangesAsync(requestAborted);
 
                     return RedirectToAction("Complete", new { id = order.OrderId });
                 }
@@ -73,7 +74,7 @@ namespace MusicStore.Controllers
         public async Task<IActionResult> Complete(int id)
         {
             // Validate customer owns this order
-            bool isValid = await _dbContext.Orders.AnyAsync(
+            bool isValid = await DbContext.Orders.AnyAsync(
                 o => o.OrderId == id &&
                 o.Username == Context.User.Identity.GetUserName());
 

--- a/src/MusicStore/Controllers/CheckoutController.cs
+++ b/src/MusicStore/Controllers/CheckoutController.cs
@@ -32,7 +32,7 @@ namespace MusicStore.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> AddressAndPayment(CancellationToken requestAborted, Order order)
+        public async Task<IActionResult> AddressAndPayment(Order order, CancellationToken cancellationToken)
         {
             var formCollection = await Context.Request.ReadFormAsync();
 
@@ -56,7 +56,7 @@ namespace MusicStore.Controllers
                     await cart.CreateOrder(order);
 
                     // Save all changes
-                    await DbContext.SaveChangesAsync(requestAborted);
+                    await DbContext.SaveChangesAsync(cancellationToken);
 
                     return RedirectToAction("Complete", new { id = order.OrderId });
                 }

--- a/src/MusicStore/Controllers/HomeController.cs
+++ b/src/MusicStore/Controllers/HomeController.cs
@@ -10,13 +10,18 @@ namespace MusicStore.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly MusicStoreContext _dbContext;
-        private readonly IMemoryCache _cache;
-
-        public HomeController(MusicStoreContext dbContext, IMemoryCache memoryCache)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
-            _cache = memoryCache;
+            get;
+            set;
+        }
+
+        [Activate]
+        public IMemoryCache MemoryCache
+        {
+            get;
+            set;
         }
 
         //
@@ -24,7 +29,7 @@ namespace MusicStore.Controllers
         public async Task<IActionResult> Index()
         {
             // Get most popular albums
-            var albums = await _cache.GetOrSet("topselling", async context =>
+            var albums = await MemoryCache.GetOrSet("topselling", async context =>
             {
                 //Refresh it every 10 minutes. Let this be the last item to be removed by cache if cache GC kicks in.
                 context.SetAbsoluteExpiration(TimeSpan.FromMinutes(10));
@@ -48,7 +53,7 @@ namespace MusicStore.Controllers
             // the albums with the highest count
 
             // TODO [EF] We don't query related data as yet, so the OrderByDescending isn't doing anything
-            return await _dbContext.Albums
+            return await DbContext.Albums
                 .OrderByDescending(a => a.OrderDetails.Count())
                 .Take(count)
                 .ToListAsync();

--- a/src/MusicStore/Controllers/ShoppingCartController.cs
+++ b/src/MusicStore/Controllers/ShoppingCartController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Framework.DependencyInjection;
@@ -9,19 +10,18 @@ namespace MusicStore.Controllers
 {
     public class ShoppingCartController : Controller
     {
-        private readonly MusicStoreContext _dbContext;
-
-        public ShoppingCartController(MusicStoreContext dbContext)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = dbContext;
+            get;
+            set;
         }
 
         //
         // GET: /ShoppingCart/
-
         public async Task<IActionResult> Index()
         {
-            var cart = ShoppingCart.GetCart(_dbContext, Context);
+            var cart = ShoppingCart.GetCart(DbContext, Context);
 
             // Set up our ViewModel
             var viewModel = new ShoppingCartViewModel
@@ -37,18 +37,18 @@ namespace MusicStore.Controllers
         //
         // GET: /ShoppingCart/AddToCart/5
 
-        public async Task<IActionResult> AddToCart(int id)
+        public async Task<IActionResult> AddToCart(CancellationToken requestAborted, int id)
         {
             // Retrieve the album from the database
-            var addedAlbum = _dbContext.Albums
+            var addedAlbum = DbContext.Albums
                 .Single(album => album.AlbumId == id);
 
             // Add it to the shopping cart
-            var cart = ShoppingCart.GetCart(_dbContext, Context);
+            var cart = ShoppingCart.GetCart(DbContext, Context);
 
             cart.AddToCart(addedAlbum);
 
-            await _dbContext.SaveChangesAsync(Context.RequestAborted);
+            await DbContext.SaveChangesAsync(requestAborted);
 
             // Go back to the main store page for more shopping
             return RedirectToAction("Index");
@@ -57,7 +57,7 @@ namespace MusicStore.Controllers
         //
         // AJAX: /ShoppingCart/RemoveFromCart/5
         [HttpPost]
-        public async Task<IActionResult> RemoveFromCart(int id)
+        public async Task<IActionResult> RemoveFromCart(CancellationToken requestAborted, int id)
         {
             var formParameters = await Context.Request.ReadFormAsync();
             var requestVerification = formParameters["RequestVerificationToken"];
@@ -79,10 +79,10 @@ namespace MusicStore.Controllers
             antiForgery.Validate(Context, new AntiForgeryTokenSet(formToken, cookieToken));
 
             // Retrieve the current user's shopping cart
-            var cart = ShoppingCart.GetCart(_dbContext, Context);
+            var cart = ShoppingCart.GetCart(DbContext, Context);
 
             // Get the name of the album to display confirmation
-            var cartItem = await _dbContext.CartItems
+            var cartItem = await DbContext.CartItems
                 .Where(item => item.CartItemId == id)
                 .Include(c => c.Album)
                 .SingleOrDefaultAsync();
@@ -90,7 +90,7 @@ namespace MusicStore.Controllers
             // Remove from cart
             int itemCount = cart.RemoveFromCart(id);
 
-            await _dbContext.SaveChangesAsync(Context.RequestAborted);
+            await DbContext.SaveChangesAsync(requestAborted);
 
             string removed = (itemCount > 0) ? " 1 copy of " : string.Empty;
 

--- a/src/MusicStore/Controllers/ShoppingCartController.cs
+++ b/src/MusicStore/Controllers/ShoppingCartController.cs
@@ -37,7 +37,7 @@ namespace MusicStore.Controllers
         //
         // GET: /ShoppingCart/AddToCart/5
 
-        public async Task<IActionResult> AddToCart(CancellationToken requestAborted, int id)
+        public async Task<IActionResult> AddToCart(int id, CancellationToken cancellationToken)
         {
             // Retrieve the album from the database
             var addedAlbum = DbContext.Albums
@@ -48,7 +48,7 @@ namespace MusicStore.Controllers
 
             cart.AddToCart(addedAlbum);
 
-            await DbContext.SaveChangesAsync(requestAborted);
+            await DbContext.SaveChangesAsync(cancellationToken);
 
             // Go back to the main store page for more shopping
             return RedirectToAction("Index");
@@ -57,7 +57,7 @@ namespace MusicStore.Controllers
         //
         // AJAX: /ShoppingCart/RemoveFromCart/5
         [HttpPost]
-        public async Task<IActionResult> RemoveFromCart(CancellationToken requestAborted, int id)
+        public async Task<IActionResult> RemoveFromCart(int id, CancellationToken cancellationToken)
         {
             var formParameters = await Context.Request.ReadFormAsync();
             var requestVerification = formParameters["RequestVerificationToken"];
@@ -90,7 +90,7 @@ namespace MusicStore.Controllers
             // Remove from cart
             int itemCount = cart.RemoveFromCart(id);
 
-            await DbContext.SaveChangesAsync(requestAborted);
+            await DbContext.SaveChangesAsync(cancellationToken);
 
             string removed = (itemCount > 0) ? " 1 copy of " : string.Empty;
 

--- a/src/MusicStore/Controllers/StoreController.cs
+++ b/src/MusicStore/Controllers/StoreController.cs
@@ -9,32 +9,35 @@ namespace MusicStore.Controllers
 {
     public class StoreController : Controller
     {
-        private readonly MusicStoreContext _dbContext;
-        private readonly IMemoryCache _cache;
-
-        public StoreController(MusicStoreContext context, IMemoryCache memoryCache)
+        [Activate]
+        public MusicStoreContext DbContext
         {
-            _dbContext = context;
-            _cache = memoryCache;
+            get;
+            set;
+        }
+
+        [Activate]
+        public IMemoryCache MemoryCache
+        {
+            get;
+            set;
         }
 
         //
         // GET: /Store/
-
         public async Task<IActionResult> Index()
         {
-            var genres = await _dbContext.Genres.ToListAsync();
+            var genres = await DbContext.Genres.ToListAsync();
 
             return View(genres);
         }
 
         //
         // GET: /Store/Browse?genre=Disco
-
         public async Task<IActionResult> Browse(string genre)
         {
             // Retrieve Genre genre and its Associated associated Albums albums from database
-            var genreModel = await _dbContext.Genres
+            var genreModel = await DbContext.Genres
                 .Include(g => g.Albums)
                 .Where(g => g.Name == genre)
                 .FirstOrDefaultAsync();
@@ -44,12 +47,12 @@ namespace MusicStore.Controllers
 
         public async Task<IActionResult> Details(int id)
         {
-            var album = await _cache.GetOrSet(string.Format("album_{0}", id), async context =>
+            var album = await MemoryCache.GetOrSet(string.Format("album_{0}", id), async context =>
             {
                 //Remove it from cache if not retrieved in last 10 minutes
                 context.SetSlidingExpiration(TimeSpan.FromMinutes(10));
 
-                return await _dbContext.Albums
+                return await DbContext.Albums
                     .Where(a => a.AlbumId == id)
                     .Include(a => a.Artist)
                     .Include(a => a.Genre)


### PR DESCRIPTION
@rynowak, @yishaigalatzer, and @Praburaj 

1. Make CancellationToken for an action parameter so that users don't have to directly access Context.RequestAborted. In this way, users don't have to mock HttpContext for CancellationToken. 

2. Use the property DI instead of the constructor DI for SignInManager, UserManager, DbContext, IConnectionManager, IMemoryCache so that users can selectively mock those objects.

Thanks,

Note:
1. I didn't change the original code styles. For example, I didn't do any extra indentation. 
2. I'll add the unit tests for each controller later
