### PR TITLE
Ensure the latest AspNet.Loader.dll is retrieved

### DIFF
--- a/src/MusicStore/CopyAspNetLoader.cmd
+++ b/src/MusicStore/CopyAspNetLoader.cmd
@@ -3,6 +3,6 @@ md wwwroot\bin
 
 SET ASPNETLOADER_PACKAGE_BASEPATH=%USERPROFILE%\.k\packages\Microsoft.AspNet.Loader.IIS.Interop
 REM figure out the path of AspNet.Loader.dll
-FOR /F %%j IN ('dir /b /o:-d %ASPNETLOADER_PACKAGE_BASEPATH%\*') do (SET AspNetLoaderPath=%ASPNETLOADER_PACKAGE_BASEPATH%\%%j\tools\AspNet.Loader.dll)
+FOR /F %%j IN ('dir /b /o:D %ASPNETLOADER_PACKAGE_BASEPATH%\*') do (SET AspNetLoaderPath=%ASPNETLOADER_PACKAGE_BASEPATH%\%%j\tools\AspNet.Loader.dll)
 echo Found AspNetLoader.dll at %AspNetLoaderPath%. Copying to bin\
 copy %AspNetLoaderPath% wwwroot\bin\


### PR DESCRIPTION
Current script actually ensure the oldest one gets copied. Changed to the opposite which is the desirable behavior.