### PR TITLE
Ef : Enabled Autogeneration for ArtistId & GenreId using sequence

### DIFF
--- a/src/MusicStore/Models/MusicStoreContext.cs
+++ b/src/MusicStore/Models/MusicStoreContext.cs
@@ -25,9 +25,9 @@ namespace MusicStore.Models
             builder.Entity<CartItem>().Key(c => c.CartItemId);
             builder.Entity<OrderDetail>().Key(o => o.OrderDetailId);
 
-            // TODO: Remove this when we start using auto generated values
-            builder.Entity<Artist>().Property(a => a.ArtistId).GenerateValueOnAdd(generateValue: false).ForSqlServer(b => b.UseNoValueGeneration());
-            builder.Entity<Genre>().Property(g => g.GenreId).GenerateValueOnAdd(generateValue: false).ForSqlServer(b => b.UseNoValueGeneration());
+            // TODO: Remove UseSequence when explicit values insertion removed. Auto generated values enabled. Default is Identity, using sequence at present to allow explicit value insertion.
+            builder.Entity<Artist>().Property(a => a.ArtistId).ForSqlServer(b => b.UseSequence());
+            builder.Entity<Genre>().Property(g => g.GenreId).ForSqlServer(b => b.UseSequence());
 
             //Deleting an album fails with this relation
             builder.Entity<Album>().Ignore(a => a.OrderDetails);


### PR DESCRIPTION
Recent change in EF requires the principal root in chain of foreignkey to have GenerateValueOnAdd enabled.
Due to this GenreId & ArtistId requires GenerateValueOnAdd as true. This is done by conventions automatically.
Since explicit values are being inserted in both the columns using sequence instead of Identity (which is also default by convention)