### PR TITLE
Fixing test helpers

### DIFF
--- a/test/E2ETests/Common/DeploymentUtility.cs
+++ b/test/E2ETests/Common/DeploymentUtility.cs
@@ -260,7 +260,7 @@ namespace E2ETests
 
         private static string SwitchPathToRuntimeFlavor(RuntimeFlavor runtimeFlavor, RuntimeArchitecture runtimeArchitecture, ILogger logger)
         {
-            var runtimePath = Environment.GetCommandLineArgs().First();
+            var runtimePath = Process.GetCurrentProcess().MainModule.FileName;
             logger.LogInformation(string.Empty);
             logger.LogInformation("Current runtime path is : {0}", runtimePath);
 


### PR DESCRIPTION
The command to execute tests have changed to dnx . test. As a result the path to dnx.exe cannot be retrieved from Environment.CommandLineArgs().

Changing the way to obtain path to dnx.exe.