### PR TITLE
Updating build.sh to use /bin/bash instead of /bin/sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild


### PR DESCRIPTION
Currently due to this command source is not recognized. This seems to be fixed in a bunch of repos already.