### PR TITLE
Bundle and deploy

### DIFF
--- a/test/E2ETests/project.json
+++ b/test/E2ETests/project.json
@@ -21,6 +21,14 @@
                 "System.Net.Http": "",
                 "System.Xml": ""
             }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.Win32.Primitives": "4.0.0-beta-*",
+                "System.Data.SqlClient": "4.0.0-beta-*",
+                "System.Net.Http": "4.0.0-beta-*",
+                "System.Xml.XmlDocument": "4.0.0-beta-*"
+            }
         }
     }
 }

--- a/test/MusicStore.Test/project.json
+++ b/test/MusicStore.Test/project.json
@@ -12,6 +12,7 @@
     "test": "xunit.runner.aspnet"
   },
   "frameworks": {
-    "dnx451": { }
+    "dnx451": { },
+    "dnxcore50": { }
   }
 }

--- a/tools/BundleAndDeploy.cmd
+++ b/tools/BundleAndDeploy.cmd
@@ -1,0 +1,3 @@
+@Echo off
+
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0BundleAndDeploy.ps1' %*"

--- a/tools/BundleAndDeploy.ps1
+++ b/tools/BundleAndDeploy.ps1
@@ -1,0 +1,90 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $projectFile,
+    [Parameter(Mandatory=$true)]
+    [string] $server,
+    [string] $serverFolder,
+    [string] $userName,
+    [string] $password
+)
+
+function UpdateHostInProjectJson($projectFile, $newhost)
+{
+    (Get-Content $projectFile) | 
+    Foreach-Object {
+        $_ -replace "http://localhost", "http://$newhost"
+    } |
+    Set-Content $projectFile 
+}
+ 
+if (-not (Test-Path $projectFile)) {
+    Write-Error "Couldn't find $projectFile"
+    exit 1
+}
+
+$projectName = (get-item $projectFile).Directory.Name
+$workDir = (get-item $projectFile).Directory.FullName
+$remoteRoot="\\" + $server
+$remoteDir= Join-Path $remoteRoot -ChildPath $serverFolder
+
+Write-Host "Project: $projectName"
+Write-Host "Work directory: $workDir"
+Write-Host "Remote dir: $remoteDir"
+Write-Host "User name: $userName"
+
+try
+{
+    if ($userName) {
+		net use $remoteRoot $password /USER:$userName
+        if ($lastexitcode -ne 0) {
+            exit 1
+        }
+    }
+
+    if (-not (Test-Path $remoteDir)) {
+        Write-Error "Remote directory $remoteDir does not exist or it is not accessible"
+        exit 1
+    }
+
+    $packDir = Join-Path $workDir -ChildPath "bin\output"
+    if (Test-Path $packDir) {
+        Write-Host "$packDir already exists. Removing it..."
+        rmdir -Recurse "$packDir"
+    }
+
+    Write-Host "Bundling the application..."
+    cd "$workDir"
+    dnvm use default -r CoreCLR -arch x64
+    dnu publish --runtime active
+    if ($lastexitcode -ne 0) {
+        Write-Error "Failed to bundle the application"
+        exit 1
+    }
+
+    $packedProjectJsonFile = Join-Path $packDir -ChildPath "approot\src\$projectName\project.json"
+    Write-Host "Setting host to $server in $packedProjectJsonFile"
+    if (-not (Test-Path $packedProjectJsonFile)) {
+        Write-Error "Couldn't find $packedProjectJsonFile"
+        exit 1
+    }
+    UpdateHostInProjectJson $packedProjectJsonFile $server
+
+    $destDir = Join-Path $remoteDir -ChildPath $projectName
+    if (Test-Path $destDir) {
+      Write-Host "$destDir already exists. Removing it..."
+      rmdir -Recurse "$destDir"
+    }
+
+    Write-Host "Copying bundled application to $destDir ..."
+    Copy-Item "$packDir" -Destination "$destDir" -Recurse
+    if ($lastexitcode -ne 0) {
+        Write-Error "Failed to copy the bundled application"
+        exit 1
+    }
+}
+finally
+{
+    if ($userName -and $remoteRoot) {
+        net use $remoteRoot /delete
+    }
+}

--- a/tools/RemoteTest.cmd
+++ b/tools/RemoteTest.cmd
@@ -1,0 +1,3 @@
+@Echo off
+
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0RemoteTest.ps1' %*"

--- a/tools/RemoteTest.ps1
+++ b/tools/RemoteTest.ps1
@@ -1,0 +1,28 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $projectFile,
+    [Parameter(Mandatory=$true)]
+    [string] $server,
+    [string] $serverFolder="dev",
+    [string] $userName,
+    [string] $password
+)
+
+Invoke-Expression ".\BundleAndDeploy.ps1 -projectFile $projectFile -server $server -serverFolder $serverFolder -userName $userName -password $password"
+
+$pass = ConvertTo-SecureString $password -AsPlainText -Force
+$cred= New-Object System.Management.Automation.PSCredential ($userName, $pass);
+
+$projectName = (get-item $projectFile).Directory.Name
+
+Set-Item WSMan:\localhost\Client\TrustedHosts "$server" -Force
+chcp 65001
+
+$remoteScript = {
+    cd C:\$using:serverFolder\$using:projectName
+	dir 
+	$env:DNX_TRACE=1
+	.\test.cmd
+}
+
+Invoke-Command -ComputerName $server -Credential $cred -ScriptBlock $remoteScript


### PR DESCRIPTION
Few changes for testing on Nano server:
- Enable the MusicStore tests to run on CoreCLR
- Script that bundles the application, copies it to the remote machine, sets up a remote PS session and then runs the tests

Please review @Praburaj , @pranavkm 