### PR TITLE
Add missing helper tag fallback attr. Closes #520

### DIFF
--- a/src/MusicStore/Views/Shared/_Layout.cshtml
+++ b/src/MusicStore/Views/Shared/_Layout.cshtml
@@ -83,7 +83,8 @@
                 asp-fallback-test="window.jQuery">
         </script>
         <script src="//ajax.aspnetcdn.com/ajax/respond/1.2.0/respond.js"
-                asp-fallback-src="~/Scripts/respond.js">
+                asp-fallback-src="~/Scripts/respond.js"
+                asp-fallback-test="window.respond">
         </script>
     </environment>
 


### PR DESCRIPTION
This commit add missing fallback test attribute to script tag helper.
This fix will remove missing fallback attribute warning from console
for this specific tag helper.

Thanks!