### PR TITLE
added missing reference to System.Data.Entity which causes build to fail.

### DIFF
--- a/src/MvcMusicStore/MvcMusicStore.csproj
+++ b/src/MvcMusicStore/MvcMusicStore.csproj
@@ -21,6 +21,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <WebGreaseLibPath>..\..\packages\WebGrease.1.5.2\lib</WebGreaseLibPath>
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -103,6 +104,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />


### PR DESCRIPTION
The line UseGlobalApplicationHostFile just added itself after I built, so I assume that's ok.