### PR TITLE
:green_heart: Fix more calls to UseDatabaseErrorPage

### DIFF
--- a/shared/Mocks/StartupOpenIdConnectTesting.cs
+++ b/shared/Mocks/StartupOpenIdConnectTesting.cs
@@ -103,7 +103,7 @@ namespace MusicStore
             // During development use the ErrorPage middleware to display error information in the browser
             app.UseDeveloperExceptionPage();
 
-            app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+            app.UseDatabaseErrorPage();
 
             // Add the runtime information page that can be used by developers
             // to see what packages are used by the application

--- a/shared/Mocks/StartupSocialTesting.cs
+++ b/shared/Mocks/StartupSocialTesting.cs
@@ -29,7 +29,7 @@ namespace MusicStore
 
         public StartupSocialTesting(IApplicationEnvironment appEnvironment, IRuntimeEnvironment runtimeEnvironment)
         {
-            //Below code demonstrates usage of multiple configuration sources. For instance a setting say 'setting1' is found in both the registered sources, 
+            //Below code demonstrates usage of multiple configuration sources. For instance a setting say 'setting1' is found in both the registered sources,
             //then the later source will win. By this way a Local config can be overridden by a different setting while deployed remotely.
             var builder = new ConfigurationBuilder()
                 .SetBasePath(appEnvironment.ApplicationBasePath)
@@ -114,7 +114,7 @@ namespace MusicStore
             // Note: Not recommended for production.
             app.UseDeveloperExceptionPage();
 
-            app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+            app.UseDatabaseErrorPage();
 
             // Add the runtime information page that can be used by developers
             // to see what packages are used by the application

--- a/src/MusicStore/StartupNtlmAuthentication.cs
+++ b/src/MusicStore/StartupNtlmAuthentication.cs
@@ -109,7 +109,7 @@ namespace MusicStore
                 listener.AuthenticationManager.AuthenticationSchemes = AuthenticationSchemes.NTLM;
             }
 
-            app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+            app.UseDatabaseErrorPage();
 
             // Add the runtime information page that can be used by developers
             // to see what packages are used by the application

--- a/src/MusicStore/StartupOpenIdConnect.cs
+++ b/src/MusicStore/StartupOpenIdConnect.cs
@@ -117,7 +117,7 @@ namespace MusicStore
             // During development use the ErrorPage middleware to display error information in the browser
             app.UseDeveloperExceptionPage();
 
-            app.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
+            app.UseDatabaseErrorPage();
 
             // Add the runtime information page that can be used by developers
             // to see what packages are used by the application


### PR DESCRIPTION
Some more calls that I missed in my previous commit. The overload being used in the templates has swapped to a builder pattern (see aspnet/Diagnostics#184). But rather than updating to the new signature, just swapping to the parameterless overload since it enables everything by default (same as UseDeveloperExceptionPage()).