### PR TITLE
Clean up E2E tests

### DIFF
--- a/MusicStore.sln
+++ b/MusicStore.sln
@@ -35,6 +35,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Facebook", "Facebook", "{B5
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{E839AEB0-7926-4FEE-B22C-11AF7EF5D4BF}"
+	ProjectSection(SolutionItems) = preProject
+		shared\MusicStoreConfig.cs = shared\MusicStoreConfig.cs
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{78715843-B625-414E-9074-56908C48EF28}"
 	ProjectSection(SolutionItems) = preProject

--- a/MusicStore.sln.DotSettings
+++ b/MusicStore.sln.DotSettings
@@ -1,9 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	
-	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=EntityFramework/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="EntityFramework"&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;CSRemoveCodeRedundancies&gt;True&lt;/CSRemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;XMLReformatCode&gt;True&lt;/XMLReformatCode&gt;&lt;CSUpdateFileHeader&gt;True&lt;/CSUpdateFileHeader&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;/Profile&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=MusicStore/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="MusicStore"&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;CSRemoveCodeRedundancies&gt;True&lt;/CSRemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;XMLReformatCode&gt;True&lt;/XMLReformatCode&gt;&lt;CSUpdateFileHeader&gt;True&lt;/CSUpdateFileHeader&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;/Profile&gt;</s:String>
 	
-	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">EntityFramework</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">EntityFramework</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">MusicStore</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">MusicStore</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_ARGUMENT/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_CALLS_CHAIN/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
@@ -45,7 +45,8 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
 	
 	
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue"></s:String>
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Copyright (c) .NET Foundation. All rights reserved.&#xD;
+See License.txt in the project root for license information</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Constructor/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Generate/=Constructor/Options/=XmlDocumentation/@EntryIndexedValue">True</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Generate/=Equality/@KeyIndexDefined">True</s:Boolean>
@@ -63,6 +64,45 @@
 	<s:Boolean x:Key="/Default/CodeStyle/IntroduceVariableUseVar/UseVarForIntroduceVariableRefactoring/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FCONSTANT/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FBLOCK_005FSCOPE_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FGLOBAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLABEL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FCONSTRUCTOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FLOCAL_005FVARIABLE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FOBJECT_005FPROPERTY_005FOF_005FFUNCTION/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=JS_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FCLASS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FENUM_005FMEMBER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FINTERFACE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FEXPORTED/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FMODULE_005FLOCAL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPRIVATE_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPROTECTED_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FMEMBER_005FACCESSOR/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FSTATIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FPUBLIC_005FTYPE_005FMETHOD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/JavaScriptNaming/UserRules/=TS_005FTYPE_005FPARAMETER/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/EventHandlerPatternLong/@EntryValue">$object$_On$event$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FHTML_005FCONTROL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FNAME/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FPREFIX/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/shared/MusicStoreConfig.cs
+++ b/shared/MusicStoreConfig.cs
@@ -1,0 +1,7 @@
+namespace MusicStore
+{
+    public class StoreConfig
+    {
+        public const string ConnectionStringKey = "Data__DefaultConnection__ConnectionString";
+    }
+}

--- a/src/MusicStore/Startup.cs
+++ b/src/MusicStore/Startup.cs
@@ -52,7 +52,7 @@ namespace MusicStore
                 services.AddEntityFramework()
                         .AddSqlServer()
                         .AddDbContext<MusicStoreContext>(options =>
-                            options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
+                            options.UseSqlServer(Configuration[StoreConfig.ConnectionStringKey.Replace("__",":")]));
             }
 
             // Add Identity services to the services container

--- a/src/MusicStore/config.json
+++ b/src/MusicStore/config.json
@@ -8,7 +8,7 @@
         "DefaultConnection": {
             // Use a shared (and running) LocalDB database when executing in IIS e.g.
             // "Server=(localdb)\\.\\IIS_DB;Database=MusicStore;Trusted_Connection=False;MultipleActiveResultSets=true;User ID=iis_login;Password=********"
-            "Connectionstring": "Server=(localdb)\\MSSQLLocalDB;Database=MusicStore;Trusted_Connection=True;MultipleActiveResultSets=true;Connect Timeout=30;"
+            "ConnectionString": "Server=(localdb)\\MSSQLLocalDB;Database=MusicStore;Trusted_Connection=True;MultipleActiveResultSets=true;Connect Timeout=30;"
         }
     }
 }

--- a/test/E2ETests/Common/XunitLogger.cs
+++ b/test/E2ETests/Common/XunitLogger.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// See License.txt in the project root for license information
+
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+using System.Linq;
+
+namespace E2ETests.Common
+{
+    public class XunitLogger : ILogger, IDisposable
+    {
+        private readonly LogLevel _minLogLevel;
+        private readonly ITestOutputHelper _output;
+        private bool _disposed;
+
+        public XunitLogger(ITestOutputHelper output, LogLevel minLogLevel)
+        {
+            _minLogLevel = minLogLevel;
+            _output = output;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+            var firstLinePrefix = "| " + logLevel + ": ";
+            var lines = formatter(state, exception).Split('\n');
+            _output.WriteLine(firstLinePrefix + lines.First());
+
+            var additionalLinePrefix = "|" + new string(' ', firstLinePrefix.Length - 1);
+            foreach (var line in lines.Skip(1))
+            {
+                _output.WriteLine(additionalLinePrefix + line.Trim('\r'));
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+            => logLevel >= _minLogLevel && !_disposed;
+
+        public IDisposable BeginScopeImpl(object state)
+            => new NullScope();
+
+        private class NullScope : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            _disposed = true;
+        }
+    }
+}

--- a/test/E2ETests/Implementation/MicrosoftAccountAuthenticationScenarios.cs
+++ b/test/E2ETests/Implementation/MicrosoftAccountAuthenticationScenarios.cs
@@ -17,7 +17,7 @@ namespace E2ETests
             _httpClientHandler = new HttpClientHandler() { AllowAutoRedirect = false };
             _httpClient = new HttpClient(_httpClientHandler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            var response = await _httpClient.GetAsync("Account/Login");
+            var response = await DoGetAsync("Account/Login");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Signing in with Microsoft account");
@@ -29,13 +29,13 @@ namespace E2ETests
             };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLogin", content);
-            Assert.Equal<string>("https://login.live.com/oauth20_authorize.srf", response.Headers.Location.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));
+            response = await DoPostAsync("Account/ExternalLogin", content);
+            Assert.StartsWith("https://login.microsoftonline.com/common/oauth2/v2.0/authorize", response.Headers.Location.ToString());
             var queryItems = new QueryCollection(QueryHelpers.ParseQuery(response.Headers.Location.Query));
             Assert.Equal<string>("code", queryItems["response_type"]);
             Assert.Equal<string>("[ClientId]", queryItems["client_id"]);
             Assert.Equal<string>(_deploymentResult.ApplicationBaseUri + "signin-microsoft", queryItems["redirect_uri"]);
-            Assert.Equal<string>("wl.basic wl.signin", queryItems["scope"]);
+            Assert.Equal<string>("https://graph.microsoft.com/user.read wl.basic wl.signin", queryItems["scope"]);
             Assert.Equal<string>("ValidStateData", queryItems["state"]);
             Assert.Equal<string>("custom", queryItems["custom_redirect_uri"]);
 
@@ -46,7 +46,7 @@ namespace E2ETests
             _httpClientHandler = new HttpClientHandler() { AllowAutoRedirect = false };
             _httpClient = new HttpClient(_httpClientHandler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            response = await _httpClient.GetAsync("Account/Login");
+            response = await DoGetAsync("Account/Login");
             responseContent = await response.Content.ReadAsStringAsync();
             formParameters = new List<KeyValuePair<string, string>>
             {
@@ -56,11 +56,11 @@ namespace E2ETests
             };
 
             content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLogin", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/ExternalLogin", content);
+            response = await DoGetAsync(response.Headers.Location);
             //Post a message to the MicrosoftAccount middleware
-            response = await _httpClient.GetAsync("signin-microsoft?code=ValidCode&state=ValidStateData");
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoGetAsync("signin-microsoft?code=ValidCode&state=ValidStateData");
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
 
@@ -78,21 +78,21 @@ namespace E2ETests
             };
 
             content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLoginConfirmation", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/ExternalLoginConfirmation", content);
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(string.Format("Hello {0}!", "microsoft@test.com"), responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Log off", responseContent, StringComparison.OrdinalIgnoreCase);
             //Verify cookie sent
-            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
-            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.ExternalLogin"));
+            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
+            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(ExternalLoginCookieName));
             _logger.LogInformation("Successfully signed in with user '{email}'", "microsoft@test.com");
 
             _logger.LogInformation("Verifying if the middleware events were fired");
             //Check for a non existing item
-            response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
+            response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
             //This action requires admin permissions. If events are fired this permission is granted
             _logger.LogInformation(await response.Content.ReadAsStringAsync());
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/test/E2ETests/Implementation/OpenIdConnectLoginScenarios.cs
+++ b/test/E2ETests/Implementation/OpenIdConnectLoginScenarios.cs
@@ -17,7 +17,7 @@ namespace E2ETests
             _httpClientHandler = new HttpClientHandler() { AllowAutoRedirect = false };
             _httpClient = new HttpClient(_httpClientHandler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            var response = await _httpClient.GetAsync("Account/Login");
+            var response = await DoGetAsync("Account/Login");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Signing in with OpenIdConnect account");
@@ -29,7 +29,7 @@ namespace E2ETests
             };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLogin", content);
+            response = await DoPostAsync("Account/ExternalLogin", content);
             Assert.Equal<string>("https://login.windows.net/4afbc689-805b-48cf-a24c-d4aa3248a248/oauth2/authorize", response.Headers.Location?.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));
             var queryItems = new QueryCollection(QueryHelpers.ParseQuery(response.Headers.Location?.Query));
             Assert.Equal<string>("c99497aa-3ee2-4707-b8a8-c33f51323fef", queryItems["client_id"]);
@@ -54,7 +54,7 @@ namespace E2ETests
                 new KeyValuePair<string, string>("session_state", "d0b59ffa-2df9-4d8c-b43a-2c410987f4ae")
             };
 
-            response = await _httpClient.PostAsync(string.Empty, new FormUrlEncodedContent(token.ToArray()));
+            response = await DoPostAsync(string.Empty, new FormUrlEncodedContent(token.ToArray()));
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal(_deploymentResult.ApplicationBaseUri + "Account/ExternalLoginCallback?ReturnUrl=%2F", response.RequestMessage.RequestUri.AbsoluteUri);
@@ -66,26 +66,26 @@ namespace E2ETests
             };
 
             content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLoginConfirmation", content);
+            response = await DoPostAsync("Account/ExternalLoginConfirmation", content);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(string.Format("Hello {0}!", "User3@aspnettest.onmicrosoft.com"), responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Log off", responseContent, StringComparison.OrdinalIgnoreCase);
             //Verify cookie sent
-            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
-            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.ExternalLogin"));
+            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
+            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(ExternalLoginCookieName));
             _logger.LogInformation("Successfully signed in with user '{email}'", "User3@aspnettest.onmicrosoft.com");
 
             _logger.LogInformation("Verifying if the middleware events were fired");
             //Check for a non existing item
-            response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
+            response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
             //This action requires admin permissions. If events are fired this permission is granted
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             _logger.LogInformation("Middleware events were fired successfully");
 
             _logger.LogInformation("Verifying the OpenIdConnect logout flow..");
-            response = await _httpClient.GetAsync(string.Empty);
+            response = await DoGetAsync(string.Empty);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
             ValidateLayoutPage(responseContent);
@@ -100,8 +100,8 @@ namespace E2ETests
             handler.CookieContainer.Add(new Uri(_deploymentResult.ApplicationBaseUri), _httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)));
             _httpClient = new HttpClient(handler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            response = await _httpClient.PostAsync("Account/LogOff", content);
-            Assert.Null(handler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+            response = await DoPostAsync("Account/LogOff", content);
+            Assert.Null(handler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
             Assert.Equal<string>(
                 "https://login.windows.net/4afbc689-805b-48cf-a24c-d4aa3248a248/oauth2/logout",
                 response.Headers.Location.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));

--- a/test/E2ETests/Implementation/TwitterLoginScenarios.cs
+++ b/test/E2ETests/Implementation/TwitterLoginScenarios.cs
@@ -20,7 +20,7 @@ namespace E2ETests
             _httpClientHandler = new HttpClientHandler() { AllowAutoRedirect = false };
             _httpClient = new HttpClient(_httpClientHandler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            var response = await _httpClient.GetAsync("Account/Login");
+            var response = await DoGetAsync("Account/Login");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Signing in with Twitter account");
@@ -32,8 +32,8 @@ namespace E2ETests
             };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLogin", content);
-            Assert.Equal<string>("https://api.twitter.com/oauth/authenticate", response.Headers.Location.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));
+            response = await DoPostAsync("Account/ExternalLogin", content);
+            Assert.StartsWith("https://api.twitter.com/oauth/authenticate", response.Headers.Location.ToString());
             var queryItems = new QueryCollection(QueryHelpers.ParseQuery(response.Headers.Location.Query));
             Assert.Equal<string>("custom", queryItems["custom_redirect_uri"]);
             Assert.Equal<string>("valid_oauth_token", queryItems["oauth_token"]);
@@ -44,7 +44,7 @@ namespace E2ETests
             _httpClientHandler = new HttpClientHandler() { AllowAutoRedirect = false };
             _httpClient = new HttpClient(_httpClientHandler) { BaseAddress = new Uri(_deploymentResult.ApplicationBaseUri) };
 
-            response = await _httpClient.GetAsync("Account/Login");
+            response = await DoGetAsync("Account/Login");
             responseContent = await response.Content.ReadAsStringAsync();
             formParameters = new List<KeyValuePair<string, string>>
             {
@@ -54,11 +54,11 @@ namespace E2ETests
             };
 
             content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLogin", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/ExternalLogin", content);
+            response = await DoGetAsync(response.Headers.Location);
             //Post a message to the Facebook middleware
-            response = await _httpClient.GetAsync("signin-twitter?oauth_token=valid_oauth_token&oauth_verifier=valid_oauth_verifier");
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoGetAsync("signin-twitter?oauth_token=valid_oauth_token&oauth_verifier=valid_oauth_verifier");
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
 
@@ -78,21 +78,21 @@ namespace E2ETests
             };
 
             content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/ExternalLoginConfirmation", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/ExternalLoginConfirmation", content);
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
 
             Assert.Contains(string.Format("Hello {0}!", "twitter@test.com"), responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Log off", responseContent, StringComparison.OrdinalIgnoreCase);
             //Verify cookie sent
-            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
-            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.ExternalLogin"));
+            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
+            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(ExternalLoginCookieName));
             _logger.LogInformation("Successfully signed in with user '{email}'", "twitter@test.com");
 
             _logger.LogInformation("Verifying if the middleware events were fired");
             //Check for a non existing item
-            response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
+            response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", "123"));
             //This action requires admin permissions. If events are fired this permission is granted
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             _logger.LogInformation("Middleware events were fired successfully");

--- a/test/E2ETests/Implementation/Validator.cs
+++ b/test/E2ETests/Implementation/Validator.cs
@@ -37,7 +37,7 @@ namespace E2ETests
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                Console.WriteLine("Home page content : {0}", responseContent);
+                _logger.LogInformation("Home page content : {0}", responseContent);
             }
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -177,6 +177,7 @@ namespace E2ETests
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
             response = await _httpClient.PostAsync("Account/Register", content);
+            await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
             Assert.Contains("<div class=\"text-danger validation-summary-errors\" data-valmsg-summary=\"true\"><ul><li>The password and confirmation password do not match.</li>", responseContent, StringComparison.OrdinalIgnoreCase);
@@ -492,7 +493,11 @@ namespace E2ETests
         {
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                _logger.LogError(await response.Content.ReadAsStringAsync());
+                _logger.LogError(
+                    "Headers: {0}",
+                    string.Join("\n", response.Headers.Select(h => h.Key + "=" + string.Join(",", h.Value))));
+                var content = await response.Content.ReadAsStringAsync();
+                _logger.LogError("Content: Length={0}\n{1}", content.Length, content);
                 throw new Exception(string.Format("Received the above response with status code : {0}", response.StatusCode));
             }
         }

--- a/test/E2ETests/Implementation/Validator.cs
+++ b/test/E2ETests/Implementation/Validator.cs
@@ -6,15 +6,22 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Testing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Microsoft.AspNetCore.Identity;
 using Xunit;
 
 namespace E2ETests
 {
     public partial class Validator
     {
+        private static readonly string IdentityCookieName = new IdentityCookieOptions().ApplicationCookieAuthenticationScheme;
+        private static readonly string ExternalLoginCookieName = new IdentityCookieOptions().ExternalCookieAuthenticationScheme;
         private HttpClient _httpClient;
+
         private HttpClientHandler _httpClientHandler;
+
         private readonly ILogger _logger;
+
         private readonly DeploymentResult _deploymentResult;
 
         public Validator(
@@ -27,6 +34,73 @@ namespace E2ETests
             _httpClientHandler = httpClientHandler;
             _logger = logger;
             _deploymentResult = deploymentResult;
+        }
+
+        private Task<HttpResponseMessage> DoGetAsync(string uri)
+            => DoGetAsync(new Uri(uri, UriKind.RelativeOrAbsolute));
+
+        private async Task<HttpResponseMessage> DoGetAsync(Uri uri)
+        {
+            _logger.LogInformation("GET {0}", uri.ToString());
+            var resp= await _httpClient.GetAsync(uri);
+            LogHeaders(resp, LogLevel.Information);
+            SaveCookies(resp);
+            return resp;
+        }
+
+        private Task<HttpResponseMessage> DoPostAsync(string uri, HttpContent content)
+            => DoPostAsync(new Uri(uri, UriKind.RelativeOrAbsolute), content);
+
+        private async Task<HttpResponseMessage> DoPostAsync(Uri uri, HttpContent content)
+        {
+            _logger.LogInformation("POST {0}", uri.ToString());
+            var resp= await _httpClient.PostAsync(uri, content);
+            LogHeaders(resp, LogLevel.Information);
+            SaveCookies(resp);
+            return resp;
+        }
+        private void LogHeaders(HttpResponseMessage response, LogLevel logLevel)
+        {
+            var requestHeaders = string.Join("\n", response.RequestMessage.Headers.Select(h => h.Key + "=" + string.Join(",", h.Value)));
+            _logger.Log(logLevel, 0,
+               new FormattedLogValues("Request headers: {0}", requestHeaders),
+               exception: null,
+               formatter: (o, e) => o.ToString());
+
+            var responseHeaders = string.Join("\n", response.Headers.Select(h => h.Key + "=" + string.Join(",", h.Value)));
+            _logger.Log(logLevel, 0,
+                new FormattedLogValues("Response headers: {0}", responseHeaders),
+                exception: null,
+                formatter: (o, e) => o.ToString());
+        }
+
+        // TODO https://github.com/dotnet/corefx/issues/6737
+        private void SaveCookies(HttpResponseMessage response)
+        {
+            if (!_httpClientHandler.UseCookies)
+            {
+                return;
+            }
+            foreach (var cookieString in response.Headers
+                .Where(k => k.Key.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase))
+                .SelectMany(k => k.Value))
+            {
+                try
+                {
+                    var helper = new CookieContainer();
+                    helper.SetCookies(response.RequestMessage.RequestUri, cookieString);
+                    foreach (Cookie cookie in helper.GetCookies(response.RequestMessage.RequestUri))
+                    {
+                        _httpClientHandler.CookieContainer.Add(response.RequestMessage.RequestUri, cookie);
+                    }
+                }
+                catch
+                {
+                    //bad cookie
+                    _logger.LogInformation("Received bad cookie string: {0}", cookieString);
+                }
+
+            }
         }
 
         public async Task VerifyHomePage(
@@ -57,7 +131,7 @@ namespace E2ETests
             _logger.LogInformation("Application initialization successful.");
 
             _logger.LogInformation("Application runtime information");
-            //var runtimeResponse = await _httpClient.GetAsync("runtimeinfo");
+            //var runtimeResponse = await DoGetAsync("runtimeinfo");
 
             // https://github.com/aspnet/Diagnostics/issues/108
             if (_deploymentResult.DeploymentParameters.RuntimeFlavor != RuntimeFlavor.CoreClr)
@@ -94,7 +168,7 @@ namespace E2ETests
         {
             _logger.LogInformation("Validating if static contents are served..");
             _logger.LogInformation("Fetching favicon.ico..");
-            var response = await _httpClient.GetAsync("favicon.ico");
+            var response = await DoGetAsync("favicon.ico");
             await ThrowIfResponseStatusNotOk(response);
             Assert.NotNull(response.Headers.ETag);
             _logger.LogInformation("Etag received: {etag}", response.Headers.ETag.Tag);
@@ -102,13 +176,13 @@ namespace E2ETests
             //Check if you receive a NotModified on sending an etag
             _logger.LogInformation("Sending an IfNoneMatch header with e-tag");
             _httpClient.DefaultRequestHeaders.IfNoneMatch.Add(response.Headers.ETag);
-            response = await _httpClient.GetAsync("favicon.ico");
+            response = await DoGetAsync("favicon.ico");
             Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
             _httpClient.DefaultRequestHeaders.IfNoneMatch.Clear();
             _logger.LogInformation("Successfully received a NotModified status");
 
             _logger.LogInformation("Fetching /Content/bootstrap.css..");
-            response = await _httpClient.GetAsync("Content/bootstrap.css");
+            response = await DoGetAsync("Content/bootstrap.css");
             await ThrowIfResponseStatusNotOk(response);
             _logger.LogInformation("Verified static contents are served successfully");
         }
@@ -116,7 +190,7 @@ namespace E2ETests
         public async Task AccessStoreWithPermissions()
         {
             _logger.LogInformation("Trying to access the store inventory..");
-            var response = await _httpClient.GetAsync("Admin/StoreManager/");
+            var response = await DoGetAsync("Admin/StoreManager/");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal<string>(_deploymentResult.ApplicationBaseUri + "Admin/StoreManager/", response.RequestMessage.RequestUri.AbsoluteUri);
@@ -139,8 +213,8 @@ namespace E2ETests
         public async Task AccessStoreWithoutPermissions(string email = null)
         {
             _logger.LogInformation("Trying to access StoreManager that needs ManageStore claim with the current user : {email}", email ?? "Anonymous");
-            var response = await _httpClient.GetAsync("Admin/StoreManager/");
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            var response = await DoGetAsync("Admin/StoreManager/");
+            response = await DoGetAsync(response.Headers.Location);
             var responseContent = await response.Content.ReadAsStringAsync();
             ValidateLayoutPage(responseContent);
 
@@ -160,10 +234,13 @@ namespace E2ETests
         public async Task RegisterUserWithNonMatchingPasswords()
         {
             _logger.LogInformation("Trying to create user with not matching password and confirm password");
-            var response = await _httpClient.GetAsync("Account/Register");
+            var response = await DoGetAsync("Account/Register");
             await ThrowIfResponseStatusNotOk(response);
+            LogHeaders(response, LogLevel.Trace);
+
             var responseContent = await response.Content.ReadAsStringAsync();
             ValidateLayoutPage(responseContent);
+
 
             var generatedEmail = Guid.NewGuid().ToString().Replace("-", string.Empty) + "@test.com";
             _logger.LogInformation("Creating a new user with name '{email}'", generatedEmail);
@@ -176,17 +253,17 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/Register", content);
+            response = await DoPostAsync("Account/Register", content);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
-            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
             Assert.Contains("<div class=\"text-danger validation-summary-errors\" data-valmsg-summary=\"true\"><ul><li>The password and confirmation password do not match.</li>", responseContent, StringComparison.OrdinalIgnoreCase);
             _logger.LogInformation("Server side model validator rejected the user '{email}''s registration as passwords do not match.", generatedEmail);
         }
 
         public async Task<string> RegisterValidUser()
         {
-            var response = await _httpClient.GetAsync("Account/Register");
+            var response = await DoGetAsync("Account/Register");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             ValidateLayoutPage(responseContent);
@@ -202,7 +279,7 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/Register", content);
+            response = await DoPostAsync("Account/Register", content);
             responseContent = await response.Content.ReadAsStringAsync();
 
             //Account verification
@@ -212,7 +289,7 @@ namespace E2ETests
             var endIndex = responseContent.IndexOf("\">link</a>]]", startIndex);
             var confirmUrl = responseContent.Substring(startIndex, endIndex - startIndex);
             confirmUrl = WebUtility.HtmlDecode(confirmUrl);
-            response = await _httpClient.GetAsync(confirmUrl);
+            response = await DoGetAsync(confirmUrl);
             await ThrowIfResponseStatusNotOk(response);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains("Thank you for confirming your email.", responseContent, StringComparison.OrdinalIgnoreCase);
@@ -222,7 +299,7 @@ namespace E2ETests
         public async Task RegisterExistingUser(string email)
         {
             _logger.LogInformation("Trying to register a user with name '{email}' again", email);
-            var response = await _httpClient.GetAsync("Account/Register");
+            var response = await DoGetAsync("Account/Register");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Creating a new user with name '{email}'", email);
@@ -235,7 +312,7 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/Register", content);
+            response = await DoPostAsync("Account/Register", content);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains(string.Format("User name &#x27;{0}&#x27; is already taken.", email), responseContent, StringComparison.OrdinalIgnoreCase);
             _logger.LogInformation("Identity threw a valid exception that user '{email}' already exists in the system", email);
@@ -244,7 +321,7 @@ namespace E2ETests
         public async Task SignOutUser(string email)
         {
             _logger.LogInformation("Signing out from '{email}''s session", email);
-            var response = await _httpClient.GetAsync(string.Empty);
+            var response = await DoGetAsync(string.Empty);
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             ValidateLayoutPage(responseContent);
@@ -254,8 +331,8 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/LogOff", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/LogOff", content);
+            response = await DoGetAsync(response.Headers.Location);
             responseContent = await response.Content.ReadAsStringAsync();
 
             if (!Helpers.RunningOnMono)
@@ -266,7 +343,7 @@ namespace E2ETests
                 Assert.Contains("www.github.com/aspnet/MusicStore", responseContent, StringComparison.OrdinalIgnoreCase);
                 Assert.Contains("/Images/home-showcase.png", responseContent, StringComparison.OrdinalIgnoreCase);
                 //Verify cookie cleared on logout
-                Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+                Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
                 _logger.LogInformation("Successfully signed out of '{email}''s session", email);
             }
             else
@@ -279,7 +356,7 @@ namespace E2ETests
 
         public async Task SignInWithInvalidPassword(string email, string invalidPassword)
         {
-            var response = await _httpClient.GetAsync("Account/Login");
+            var response = await DoGetAsync("Account/Login");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Signing in with user '{email}'", email);
@@ -291,17 +368,17 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/Login", content);
+            response = await DoPostAsync("Account/Login", content);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains("<div class=\"text-danger validation-summary-errors\" data-valmsg-summary=\"true\"><ul><li>Invalid login attempt.</li>", responseContent, StringComparison.OrdinalIgnoreCase);
             //Verify cookie not sent
-            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+            Assert.Null(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
             _logger.LogInformation("Identity successfully prevented an invalid user login.");
         }
 
         public async Task SignInWithUser(string email, string password)
         {
-            var response = await _httpClient.GetAsync("Account/Login");
+            var response = await DoGetAsync("Account/Login");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             _logger.LogInformation("Signing in with user '{email}'", email);
@@ -313,19 +390,19 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Account/Login", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Account/Login", content);
+            response = await DoGetAsync(response.Headers.Location);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains(string.Format("Hello {0}!", email), responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Log off", responseContent, StringComparison.OrdinalIgnoreCase);
             //Verify cookie sent
-            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
             _logger.LogInformation("Successfully signed in with user '{email}'", email);
         }
 
         public async Task ChangePassword(string email)
         {
-            var response = await _httpClient.GetAsync("Manage/ChangePassword");
+            var response = await DoGetAsync("Manage/ChangePassword");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             var formParameters = new List<KeyValuePair<string, string>>
@@ -337,11 +414,11 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Manage/ChangePassword", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Manage/ChangePassword", content);
+            response = await DoGetAsync(response.Headers.Location);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains("Your password has been changed.", responseContent, StringComparison.OrdinalIgnoreCase);
-            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(".AspNetCore.Microsoft.AspNetCore.Identity.Application"));
+            Assert.NotNull(_httpClientHandler.CookieContainer.GetCookies(new Uri(_deploymentResult.ApplicationBaseUri)).GetCookieWithName(IdentityCookieName));
             _logger.LogInformation("Successfully changed the password for user '{email}'", email);
         }
 
@@ -349,7 +426,7 @@ namespace E2ETests
         {
             var albumName = Guid.NewGuid().ToString().Replace("-", string.Empty).Substring(0, 12);
             _logger.LogInformation("Trying to create an album with name '{album}'", albumName);
-            var response = await _httpClient.GetAsync("Admin/StoreManager/create");
+            var response = await DoGetAsync("Admin/StoreManager/create");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             var formParameters = new List<KeyValuePair<string, string>>
@@ -363,8 +440,8 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Admin/StoreManager/create", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Admin/StoreManager/create", content);
+            response = await DoGetAsync(response.Headers.Location);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Equal<string>(_deploymentResult.ApplicationBaseUri + "Admin/StoreManager", response.RequestMessage.RequestUri.AbsoluteUri);
             Assert.Contains(albumName, responseContent);
@@ -377,14 +454,14 @@ namespace E2ETests
             // Run some CORS validation.
             _logger.LogInformation("Fetching the album id of '{album}'", albumName);
             _httpClient.DefaultRequestHeaders.Add("Origin", "http://notpermitteddomain.com");
-            var response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
+            var response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
             await ThrowIfResponseStatusNotOk(response);
             IEnumerable<string> values;
             Assert.False(response.Headers.TryGetValues("Access-Control-Allow-Origin", out values));
 
             _httpClient.DefaultRequestHeaders.Remove("Origin");
             _httpClient.DefaultRequestHeaders.Add("Origin", "http://example.com");
-            response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
+            response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
             await ThrowIfResponseStatusNotOk(response);
             Assert.Equal("http://example.com", response.Headers.GetValues("Access-Control-Allow-Origin").First());
             _httpClient.DefaultRequestHeaders.Remove("Origin");
@@ -397,7 +474,7 @@ namespace E2ETests
         public async Task VerifyAlbumDetails(string albumId, string albumName)
         {
             _logger.LogInformation("Getting details of album with Id '{id}'", albumId);
-            var response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/Details?id={0}", albumId));
+            var response = await DoGetAsync(string.Format("Admin/StoreManager/Details?id={0}", albumId));
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains(albumName, responseContent, StringComparison.OrdinalIgnoreCase);
@@ -409,8 +486,8 @@ namespace E2ETests
         public async Task VerifyStatusCodePages()
         {
             _logger.LogInformation("Getting details of a non-existing album with Id '-1'");
-            var response = await _httpClient.GetAsync("Admin/StoreManager/Details?id=-1");
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            var response = await DoGetAsync("Admin/StoreManager/Details?id=-1");
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains("Item not found.", responseContent, StringComparison.OrdinalIgnoreCase);
@@ -418,10 +495,11 @@ namespace E2ETests
         }
 
         // This gets the view that non-admin users get to see.
+
         public async Task GetAlbumDetailsFromStore(string albumId, string albumName)
         {
             _logger.LogInformation("Getting details of album with Id '{id}'", albumId);
-            var response = await _httpClient.GetAsync(string.Format("Store/Details/{0}", albumId));
+            var response = await DoGetAsync(string.Format("Store/Details/{0}", albumId));
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains(albumName, responseContent, StringComparison.OrdinalIgnoreCase);
@@ -430,8 +508,8 @@ namespace E2ETests
         public async Task AddAlbumToCart(string albumId, string albumName)
         {
             _logger.LogInformation("Adding album id '{albumId}' to the cart", albumId);
-            var response = await _httpClient.GetAsync(string.Format("ShoppingCart/AddToCart?id={0}", albumId));
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            var response = await DoGetAsync(string.Format("ShoppingCart/AddToCart?id={0}", albumId));
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains(albumName, responseContent, StringComparison.OrdinalIgnoreCase);
@@ -442,7 +520,7 @@ namespace E2ETests
         public async Task CheckOutCartItems()
         {
             _logger.LogInformation("Checking out the cart contents...");
-            var response = await _httpClient.GetAsync("Checkout/AddressAndPayment");
+            var response = await DoGetAsync("Checkout/AddressAndPayment");
             await ThrowIfResponseStatusNotOk(response);
             var responseContent = await response.Content.ReadAsStringAsync();
 
@@ -462,8 +540,8 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            response = await _httpClient.PostAsync("Checkout/AddressAndPayment", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            response = await DoPostAsync("Checkout/AddressAndPayment", content);
+            response = await DoGetAsync(response.Headers.Location);
             responseContent = await response.Content.ReadAsStringAsync();
             Assert.Contains("<h2>Checkout Complete</h2>", responseContent, StringComparison.OrdinalIgnoreCase);
             Assert.StartsWith(_deploymentResult.ApplicationBaseUri + "Checkout/Complete/", response.RequestMessage.RequestUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase);
@@ -479,12 +557,12 @@ namespace E2ETests
                 };
 
             var content = new FormUrlEncodedContent(formParameters.ToArray());
-            var response = await _httpClient.PostAsync("Admin/StoreManager/RemoveAlbum", content);
-            response = await _httpClient.GetAsync(response.Headers.Location);
+            var response = await DoPostAsync("Admin/StoreManager/RemoveAlbum", content);
+            response = await DoGetAsync(response.Headers.Location);
             await ThrowIfResponseStatusNotOk(response);
 
             _logger.LogInformation("Verifying if the album '{album}' is deleted from store", albumName);
-            response = await _httpClient.GetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
+            response = await DoGetAsync(string.Format("Admin/StoreManager/GetAlbumIdFromName?albumName={0}", albumName));
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             _logger.LogInformation("Album '{album}' with id '{Id}' is successfully deleted from the store.", albumName, albumId);
         }
@@ -493,9 +571,7 @@ namespace E2ETests
         {
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                _logger.LogError(
-                    "Headers: {0}",
-                    string.Join("\n", response.Headers.Select(h => h.Key + "=" + string.Join(",", h.Value))));
+                LogHeaders(response, LogLevel.Information);
                 var content = await response.Content.ReadAsStringAsync();
                 _logger.LogError("Content: Length={0}\n{1}", content.Length, content);
                 throw new Exception(string.Format("Received the above response with status code : {0}", response.StatusCode));

--- a/test/E2ETests/SmokeTests.cs
+++ b/test/E2ETests/SmokeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using E2ETests.Common;
@@ -188,7 +189,7 @@ namespace E2ETests
                     var httpClient = new HttpClient(httpClientHandler)
                     {
                         BaseAddress = new Uri(deploymentResult.ApplicationBaseUri),
-                        Timeout = TimeSpan.FromSeconds(5)
+                        Timeout = TimeSpan.FromSeconds(5),
                     };
 
                     // Request to base address and check if various parts of the body are rendered

--- a/test/E2ETests/project.json
+++ b/test/E2ETests/project.json
@@ -6,6 +6,7 @@
     "../../shared/**/*.cs"
   ],
   "dependencies": {
+    "Microsoft.AspNetCore.Identity": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.OpenIdConnect": "0.1.0-*",
     "Microsoft.AspNetCore.Server.Testing": "1.0.0-*",
     "Microsoft.AspNetCore.WebUtilities": "1.0.0-*",

--- a/test/MusicStore.Test/Models/ShoppingCartTest.cs
+++ b/test/MusicStore.Test/Models/ShoppingCartTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// See License.txt in the project root for license information
+
+using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MusicStore.Models;


### PR DESCRIPTION
Should fix failing tests. Currently on CI the agents are all using the same database, across concurrent multiple tests. In order to figure out what was wrong, I had to fix these other things to make it easier to diagnose what was going wrong.
 
- Fix incorrect deployment environment variables
 - Utilize xunit logging utility for cleaner, more traceable output
 - Cleanup database creation/deletion
 - Fix name in R# settings file

cc @kichalla @pranavkm 