### PR TITLE
Increase HttpClient timeout

### DIFF
--- a/test/E2ETests/SmokeTestHelper.cs
+++ b/test/E2ETests/SmokeTestHelper.cs
@@ -15,7 +15,7 @@ namespace E2ETests
             var httpClient = new HttpClient(httpClientHandler)
             {
                 BaseAddress = new Uri(deploymentResult.ApplicationBaseUri),
-                Timeout = TimeSpan.FromSeconds(5),
+                Timeout = TimeSpan.FromSeconds(15),
             };
 
             using (httpClient)


### PR DESCRIPTION
@Tratcher @kichalla 

Win7-Universe tests fail a lot from what looks like a timeout, raising to 15 looks like it works on the failing machine