### PR TITLE
remove app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ This project is part of ASP.NET Core. You can find samples, documentation and ge
 
 **NOTE:** Since on Mono SQL client is not available the sample uses an InMemoryStore to run the application. So the changes that you make will not be persisted.
 
-### Deploy on Heroku
-To deploy MusicStore on Heroku, click the button below:
-
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-
 ###NTLM authentication
 More information at [src/MusicStore/StartupNtlmAuthentication.cs](src/MusicStore/StartupNtlmAuthentication.cs).
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,0 @@
-{
-    "name": "MusicStore",
-    "description": "ASP.NET 5 Music Store sample app",
-    "env": {
-	"BUILDPACK_URL": "https://github.com/heroku/dotnet-buildpack.git"
-    }
-}


### PR DESCRIPTION
Please note that, while I originally added this, I'm no longer working at Heroku. I propose that the button be removed since the buildpack is no longer maintained and is based on Mono, not .NET core.