### PR TITLE
Updated content root of musicstore.standalone to enable debugging in VS

### DIFF
--- a/samples/MusicStore.Standalone/Program.cs
+++ b/samples/MusicStore.Standalone/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Net.Http.Server;
@@ -14,10 +16,13 @@ namespace MusicStore.Standalone
                 .AddEnvironmentVariables(prefix: "ASPNETCORE_")
                 .Build();
 
+            var currentExecutingAssemblyFileInfo = new FileInfo(typeof(Program).GetTypeInfo().Assembly.Location);
+
             var builder = new WebHostBuilder()
                 .UseConfiguration(config)
                 .UseIISIntegration()
-                .UseStartup("MusicStore.Standalone");
+                .UseStartup("MusicStore.Standalone")
+                .UseContentRoot(currentExecutingAssemblyFileInfo.Directory.FullName);
 
             if (string.Equals(builder.GetSetting("server"), "Microsoft.AspNetCore.Server.WebListener", System.StringComparison.Ordinal))
             {


### PR DESCRIPTION
@Eilon all the tests pass with this change

Example of how the output directory looks like:

![image](https://cloud.githubusercontent.com/assets/6559784/21372943/87fb3460-c6cf-11e6-9bed-1db52ecfba04.png)
