### PR TITLE
fix remove from cart ajax done

### DIFF
--- a/samples/MusicStore/Views/ShoppingCart/Index.cshtml
+++ b/samples/MusicStore/Views/ShoppingCart/Index.cshtml
@@ -35,15 +35,15 @@
                     }).done(function (data) {
                         // Successful requests get here
                         // Update the page elements
-                        if (data.ItemCount == 0) {
-                            $('#row-' + data.DeleteId).fadeOut('slow');
+                        if (data.itemCount == 0) {
+                            $('#row-' + data.deleteId).fadeOut('slow');
                         } else {
-                            $('#item-count-' + data.DeleteId).text(data.ItemCount);
+                            $('#item-count-' + data.deleteId).text(data.itemCount);
                         }
 
-                        $('#cart-total').text(data.CartTotal);
-                        $('#update-message').text(data.Message);
-                        $('#cart-status').text(data.CartCount);
+                        $('#cart-total').text(data.cartTotal);
+                        $('#update-message').text(data.message);
+                        $('#cart-status').text(data.cartCount);
                     });
                 }
             });


### PR DESCRIPTION
This pull request fixes an issue with RemoveFromCart. Currently, the RemoveFromCart method in ShoppingCartController returns a ShoppingCartRemoveViewModel as a JsonResult that has properties which are PascalCase (i.e., Message, CartTotal, CartCount, ItemCount, DeleteId). However, the jQuery ajax call gets the data as camelCase (i.e., message, cartTotal, cartCount, itemCount, deleteId). As a result, removing an item from the cart isn't working correctly. Changing the JSON from PascalCase to camelCase fixes the problem.