### PR TITLE
Only publish ForTesting folder when needed

### DIFF
--- a/samples/MusicStore/MusicStore.csproj
+++ b/samples/MusicStore/MusicStore.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Update="ForTesting\**\*" CopyToPublishDirectory="Never" Condition=" '$(PublishForTesting)' != 'true' "/>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="$(AspNetCoreModuleVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="$(AspNetCoreVersion)" />

--- a/test/E2ETests/OpenIdConnectTests.cs
+++ b/test/E2ETests/OpenIdConnectTests.cs
@@ -80,10 +80,10 @@ namespace E2ETests
                         }
                     };
 
-                    if (applicationType == ApplicationType.Standalone)
-                    {
-                        deploymentParameters.AdditionalPublishParameters = " -r " + RuntimeEnvironment.GetRuntimeIdentifier();
-                    }
+
+                    deploymentParameters.AdditionalPublishParameters =
+                        (applicationType == ApplicationType.Standalone ? $" -r {RuntimeEnvironment.GetRuntimeIdentifier()}" : "")
+                        + " /p:PublishForTesting=true";
 
                     // Override the connection strings using environment based configuration
                     deploymentParameters.EnvironmentVariables


### PR DESCRIPTION
We don't want ForTesting to show up in the publish output unless we are testing with it. Currently it seems like OIDC tests are the only tests that actually needs ForTesting folder.