### PR TITLE
remove integration test logging

### DIFF
--- a/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
+++ b/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
@@ -1,13 +1,12 @@
-﻿using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
-using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.DotNet.PlatformAbstractions;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/MusicStore.E2ETests/OpenIdConnectTests.cs
+++ b/test/MusicStore.E2ETests/OpenIdConnectTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using E2ETests.Common;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 
 namespace E2ETests
 {

--- a/test/MusicStore.E2ETests/PublishAndRunTests.cs
+++ b/test/MusicStore.E2ETests/PublishAndRunTests.cs
@@ -1,15 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 
 namespace E2ETests
 {

--- a/test/MusicStore.E2ETests/SmokeTests.cs
+++ b/test/MusicStore.E2ETests/SmokeTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
+++ b/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
-using Microsoft.AspNetCore.Testing.xunit;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
The `LoggedTest` helper has been moved to `Microsoft.Extensions.Logging.Testing` repo.

React to aspnet/Hosting#1039