### PR TITLE
Fix test conditionals, re-enable tests.

### DIFF
--- a/test/MusicStore.E2ETests/DotnetRunTests_X64.cs
+++ b/test/MusicStore.E2ETests/DotnetRunTests_X64.cs
@@ -24,7 +24,7 @@ namespace E2ETests
         {
             return RunTests(ServerType.Kestrel, RuntimeFlavor.CoreClr, ApplicationType.Portable);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task DotnetRunTests_X64_Kestrel_Clr()
@@ -32,7 +32,7 @@ namespace E2ETests
             // CLR must be published as standalone to perform rid specific deployment
             return RunTests(ServerType.Kestrel, RuntimeFlavor.Clr, ApplicationType.Standalone);
         }
-
+#endif
         private Task RunTests(ServerType serverType, RuntimeFlavor runtimeFlavor, ApplicationType applicationType)
             => _testRunner.RunTests(serverType, runtimeFlavor, applicationType, RuntimeArchitecture.x64);
     }

--- a/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
+++ b/test/MusicStore.E2ETests/NtlmAuthentationTest.cs
@@ -13,8 +13,7 @@ using Xunit.Abstractions;
 namespace E2ETests
 {
     [Trait("E2Etests", "E2Etests")]
-    [OSSkipCondition(OperatingSystems.Linux)]
-    [OSSkipCondition(OperatingSystems.MacOSX)]
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
     public class NtlmAuthenticationTests : LoggedTest
     {
         public NtlmAuthenticationTests(ITestOutputHelper output) : base(output)
@@ -33,26 +32,26 @@ namespace E2ETests
             return NtlmAuthenticationTest(ServerType.WebListener, RuntimeFlavor.CoreClr, ApplicationType.Standalone);
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/MusicStore/issues/830")]
+        [ConditionalFact]
         public Task NtlmAuthenticationTest_IISExpress_CoreCLR_Portable()
         {
             return NtlmAuthenticationTest(ServerType.IISExpress, RuntimeFlavor.CoreClr, ApplicationType.Portable);
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/MusicStore/issues/830")]
+        [ConditionalFact]
         public Task NtlmAuthenticationTest_IISExpress_CoreCLR_Standalone()
         {
             return NtlmAuthenticationTest(ServerType.IISExpress, RuntimeFlavor.CoreClr, ApplicationType.Standalone);
         }
 
-#if NETCOREAPP2_1 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
         public Task NtlmAuthenticationTest_WebListener_CLR()
         {
             return NtlmAuthenticationTest(ServerType.WebListener, RuntimeFlavor.Clr, ApplicationType.Portable);
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/MusicStore/issues/830")]
+        [ConditionalFact(Skip = "https://github.com/aspnet/websdk/pull/322")]
         public Task NtlmAuthenticationTest_IISExpress_CLR()
         {
             return NtlmAuthenticationTest(ServerType.IISExpress, RuntimeFlavor.Clr, ApplicationType.Standalone);

--- a/test/MusicStore.E2ETests/OpenIdConnectTests.cs
+++ b/test/MusicStore.E2ETests/OpenIdConnectTests.cs
@@ -28,15 +28,14 @@ namespace E2ETests
         {
             return OpenIdConnectTestSuite(ServerType.Kestrel, RuntimeFlavor.CoreClr, ApplicationType.Standalone);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task OpenIdConnect_Kestrel_CLR()
         {
             return OpenIdConnectTestSuite(ServerType.Kestrel, RuntimeFlavor.Clr, ApplicationType.Portable);
         }
-
+#endif
         private async Task OpenIdConnectTestSuite(ServerType serverType, RuntimeFlavor runtimeFlavor, ApplicationType applicationType)
         {
             var architecture = RuntimeArchitecture.x64;

--- a/test/MusicStore.E2ETests/PublishAndRunTests_X64.cs
+++ b/test/MusicStore.E2ETests/PublishAndRunTests_X64.cs
@@ -29,7 +29,7 @@ namespace E2ETests
         {
             return RunTests(ServerType.WebListener, RuntimeFlavor.CoreClr, ApplicationType.Standalone);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task PublishAndRunTests_X64_WebListener_Clr()
@@ -37,7 +37,7 @@ namespace E2ETests
             // CLR must be published as standalone to perform rid specific deployment
             return RunTests(ServerType.WebListener, RuntimeFlavor.Clr, ApplicationType.Standalone);
         }
-
+#endif
         [Fact]
         public Task PublishAndRunTests_X64_Kestrel_CoreClr_Portable()
         {
@@ -49,7 +49,7 @@ namespace E2ETests
         {
             return RunTests(ServerType.Kestrel, RuntimeFlavor.CoreClr, ApplicationType.Standalone);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task PublishAndRunTests_X64_Kestrel_Clr()
@@ -57,7 +57,7 @@ namespace E2ETests
             // CLR must be published as standalone to perform rid specific deployment
             return RunTests(ServerType.Kestrel, RuntimeFlavor.Clr, ApplicationType.Standalone);
         }
-
+#endif
         private Task RunTests(ServerType serverType, RuntimeFlavor runtimeFlavor, ApplicationType applicationType)
             => _testRunner.RunTests(serverType, runtimeFlavor, applicationType, RuntimeArchitecture.x64);
     }

--- a/test/MusicStore.E2ETests/PublishAndRunTests_X86.cs
+++ b/test/MusicStore.E2ETests/PublishAndRunTests_X86.cs
@@ -1,4 +1,4 @@
-#if NETCOREAPP2_1 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Testing.xunit;
@@ -18,8 +18,7 @@ namespace E2ETests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task PublishAndRunTests_X86_WebListener_Clr()
         {
             // CLR must be published as standalone to perform rid specific deployment
@@ -27,8 +26,7 @@ namespace E2ETests
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task PublishAndRunTests_X86_Kestrel_Clr()
         {
             // CLR must be published as standalone to perform rid specific deployment

--- a/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
+++ b/test/MusicStore.E2ETests/SmokeTestsOnNanoServer.cs
@@ -26,8 +26,7 @@ namespace E2ETests
         }
 
         [ConditionalTheory, Trait("E2ETests", "NanoServer")]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [SkipIfEnvironmentVariableNotEnabled("RUN_TESTS_ON_NANO")]
         [InlineData(ServerType.Kestrel, 5000, ApplicationType.Standalone)]
         [InlineData(ServerType.WebListener, 5000, ApplicationType.Standalone)]
@@ -58,8 +57,7 @@ namespace E2ETests
         }
 
         [ConditionalTheory, Trait("E2Etests", "NanoServer")]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         [SkipIfEnvironmentVariableNotEnabled("RUN_TESTS_ON_NANO")]
         [InlineData(ServerType.Kestrel, 5000, ApplicationType.Portable)]
         [InlineData(ServerType.WebListener, 5000, ApplicationType.Portable)]

--- a/test/MusicStore.E2ETests/SmokeTests_X64.cs
+++ b/test/MusicStore.E2ETests/SmokeTests_X64.cs
@@ -15,63 +15,56 @@ namespace E2ETests
         {
             _smokeTestRunner = new SmokeTestRunner(output);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_WebListener_Clr()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.WebListener, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable);
         }
-
+#endif
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_WebListener_CoreClr_Portable()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.WebListener, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Portable);
         }
 
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_WebListener_CoreClr_Standalone()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.WebListener, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Standalone);
         }
-
-        [ConditionalFact(Skip = "https://github.com/aspnet/MusicStore/issues/830")]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
+        [ConditionalFact(Skip = "https://github.com/aspnet/websdk/pull/322")]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_IISExpress_Clr()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.IISExpress, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable);
         }
-
+#endif
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_IISExpress_CoreClr_Portable()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Portable);
         }
 
-        [ConditionalFact(Skip = "https://github.com/aspnet/MusicStore/issues/830")]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_IISExpress_CoreClr_Standalone()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.IISExpress, RuntimeFlavor.CoreClr, RuntimeArchitecture.x64, ApplicationType.Standalone);
         }
-
+#if !NETCOREAPP2_0 // Avoid running CLR based tests once on netcoreapp2.0 and netcoreapp2.1 each
         [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
         public Task SmokeTests_X64_Kestrel_Clr()
         {
             return _smokeTestRunner.SmokeTestSuite(ServerType.Kestrel, RuntimeFlavor.Clr, RuntimeArchitecture.x64, ApplicationType.Portable);
         }
-
+#endif
         [Fact]
         public Task SmokeTests_X64_Kestrel_CoreClr_Portable()
         {


### PR DESCRIPTION
#if CLR tests to prevent them from running twice.
Consolidate OSSkipConditions
Re-nable tests from https://github.com/aspnet/MusicStore/issues/830, except a few still broken by https://github.com/aspnet/websdk/pull/322.